### PR TITLE
data: Add generate-snapshot.ts and full data audit

### DIFF
--- a/docs/data-snapshot.md
+++ b/docs/data-snapshot.md
@@ -1,0 +1,1166 @@
+# ClearCost Data Snapshot
+
+_Generated: 2026-03-01T19:05:20.026Z_
+
+To regenerate after an import:
+```bash
+cd /Users/chrispratt/clearcost
+npx tsx --env-file=.env.local lib/data/generate-snapshot.ts
+```
+
+## 1. Data Funnel
+
+```
+DuckDB (Trilliant Oria)
+  ├─ Hospitals total:                     6,039
+  │    ├─ status=completed:               5,419  → imported to Supabase
+  │    └─ other status (excluded):          620  → never queried (see Section 4)
+  │
+  ├─ Raw charges (sum of total_charges_count across all hospitals):
+  │              6,381,051,296  (~274M, not all are for our codes)
+  │
+  └─ Filtered charges (1,010 codes, outpatient only, completed hospitals):
+                 13,115,274
+
+Supabase (current state)
+  ├─ Providers:    5,419  (5,034 geocoded, 385 null lat/lng — see Section 5)
+  └─ Charges:   12,574,168
+
+  Gap: 541,106 charges not yet in Supabase
+       (Expected if NJ/PA not yet reimported. See MISSING rows in Section 3.)
+```
+
+## 2. DuckDB Hospital Status Breakdown
+
+| Status | Count |
+|--------|------:|
+| `completed` | 5,419 |
+| `mrf_download_error` | 351 |
+| `parse_error` | 269 |
+| **Total** | **6,039** |
+
+## 3. Per-State Data Table
+
+_DuckDB: completed hospitals + filtered charge count (1,010 codes, outpatient, completed hospitals only)_
+_Supabase: providers imported + geocoding status + charges imported_
+_**MISSING** = DuckDB has completed hospitals with charges, but Supabase has 0 charges (needs import)_
+
+| State | DDB Hosps | DDB Charges | SB Providers | SB Geocoded | SB Null Loc | SB Charges | Match |
+|-------|----------:|------------:|-------------:|------------:|------------:|-----------:|-------|
+| AK | 20 | 27,777 | 20 | 20 | 0 | 27,777 | ✓ |
+| AL | 90 | 130,285 | 90 | 88 | 2 | 130,285 | ✓ |
+| AR | 98 | 91,918 | 98 | 93 | 5 | 91,918 | ✓ |
+| AZ | 97 | 98,523 | 97 | 89 | 8 | 98,523 | ✓ |
+| CA | 331 | 778,599 | 331 | 294 | 37 | 778,599 | ✓ |
+| CO | 109 | 308,236 | 109 | 97 | 12 | 308,236 | ✓ |
+| CT | 22 | 27,009 | 22 | 22 | 0 | 27,009 | ✓ |
+| DC | 53 | 1,436 | 53 | 53 | 0 | 1,436 | ✓ |
+| DE | 15 | 17,042 | 15 | 15 | 0 | 17,042 | ✓ |
+| FL | 366 | 1,842,566 | 366 | 346 | 20 | 1,842,566 | ✓ |
+| GA | 132 | 235,094 | 132 | 127 | 5 | 235,094 | ✓ |
+| HI | 19 | 27,639 | 19 | 16 | 3 | 27,639 | ✓ |
+| IA | 89 | 140,957 | 89 | 89 | 0 | 140,957 | ✓ |
+| ID | 40 | 50,558 | 40 | 39 | 1 | 50,558 | ✓ |
+| IL | 162 | 256,650 | 162 | 161 | 1 | 256,650 | ✓ |
+| IN | 133 | 149,745 | 133 | 128 | 5 | 149,745 | ✓ |
+| KS | 112 | 266,725 | 112 | 104 | 8 | 266,725 | ✓ |
+| KY | 105 | 151,767 | 105 | 103 | 2 | 151,767 | ✓ |
+| LA | 132 | 144,129 | 132 | 121 | 11 | 144,129 | ✓ |
+| MA | 100 | 141,213 | 100 | 99 | 1 | 141,213 | ✓ |
+| MD | 44 | 32,521 | 44 | 38 | 6 | 32,521 | ✓ |
+| ME | 30 | 31,519 | 30 | 30 | 0 | 31,519 | ✓ |
+| MI | 136 | 208,801 | 136 | 123 | 13 | 208,801 | ✓ |
+| MN | 78 | 127,367 | 78 | 72 | 6 | 127,367 | ✓ |
+| MO | 113 | 334,001 | 113 | 106 | 7 | 334,001 | ✓ |
+| MS | 67 | 66,537 | 67 | 62 | 5 | 66,537 | ✓ |
+| MT | 38 | 39,213 | 38 | 38 | 0 | 39,213 | ✓ |
+| NC | 110 | 180,691 | 110 | 91 | 19 | 180,691 | ✓ |
+| ND | 32 | 39,245 | 32 | 32 | 0 | 39,245 | ✓ |
+| NE | 75 | 93,157 | 75 | 73 | 2 | 93,157 | ✓ |
+| NH | 20 | 105,841 | 20 | 20 | 0 | 105,841 | ✓ |
+| NJ | 94 | 182,010 | 94 | 88 | 6 | 0 | **MISSING** |
+| NM | 37 | 16,250 | 37 | 36 | 1 | 16,250 | ✓ |
+| NV | 63 | 969,944 | 63 | 52 | 11 | 969,944 | ✓ |
+| NY | 139 | 278,626 | 139 | 136 | 3 | 278,626 | ✓ |
+| OH | 229 | 257,461 | 229 | 208 | 21 | 257,461 | ✓ |
+| OK | 97 | 105,800 | 97 | 95 | 2 | 105,800 | ✓ |
+| OR | 50 | 147,879 | 50 | 41 | 9 | 147,879 | ✓ |
+| PA | 243 | 359,096 | 243 | 232 | 11 | 0 | **MISSING** |
+| RI | 9 | 13,080 | 9 | 9 | 0 | 13,080 | ✓ |
+| SC | 70 | 110,022 | 70 | 69 | 1 | 110,022 | ✓ |
+| SD | 22 | 26,954 | 22 | 22 | 0 | 26,954 | ✓ |
+| TN | 139 | 497,229 | 139 | 134 | 5 | 497,229 | ✓ |
+| TX | 683 | 2,901,037 | 683 | 612 | 71 | 2,901,037 | ✓ |
+| UT | 58 | 148,775 | 58 | 55 | 3 | 148,775 | ✓ |
+| VA | 98 | 253,879 | 98 | 92 | 6 | 253,879 | ✓ |
+| VT | 7 | 7,530 | 7 | 7 | 0 | 7,530 | ✓ |
+| WA | 86 | 126,535 | 86 | 79 | 7 | 126,535 | ✓ |
+| WI | 142 | 203,459 | 142 | 138 | 4 | 203,459 | ✓ |
+| WV | 44 | 25,255 | 44 | 43 | 1 | 25,255 | ✓ |
+| WY | 23 | 37,725 | 23 | 22 | 1 | 37,725 | ✓ |
+| unknown | 118 | 299,967 | 118 | 75 | 43 | 299,967 | ✓ |
+
+## 4. Excluded Hospitals (status != 'completed')
+
+**620 hospitals** were excluded from the import because Trilliant did not fully
+process them — the `status != 'completed'` filter in `importProviders()` drops them before any charge
+data is queried. These are a Trilliant data quality limitation, not a ClearCost bug.
+
+### By Status
+
+| Status | Count |
+|--------|------:|
+| `mrf_download_error` | 351 |
+| `parse_error` | 269 |
+
+### Full Listing
+
+| ID | Name | State | City | Status |
+|----|------|-------|------|--------|
+| 193 | 64-0362400 Anderson Regional Main Campus | unknown | — | `mrf_download_error` |
+| 588 | 64-0362400 Anderson Regional South Campus | unknown | — | `mrf_download_error` |
+| 54 | AHN Wexford Hospital | unknown | — | `mrf_download_error` |
+| 300 | ALICE PECK DAY MEMORIAL HOSPITAL | unknown | — | `mrf_download_error` |
+| 258 | ANTELOPE MEMORIAL HOSPITAL | unknown | — | `parse_error` |
+| 37 | ATRIUM MEDICAL CENTER | unknown | — | `mrf_download_error` |
+| 201 | Acadia St Landry Hospital Service District | unknown | — | `parse_error` |
+| 264 | Advanced Diagnostics Dallas | unknown | — | `mrf_download_error` |
+| 210 | AdventHealth Glenoaks | unknown | — | `parse_error` |
+| 502 | Allegheny General Hospital | unknown | — | `mrf_download_error` |
+| 430 | Allegheny Valley Hospital | unknown | — | `mrf_download_error` |
+| 168 | Altus Emergency Centers - Lake Jackson | unknown | — | `parse_error` |
+| 39 | Altus Emergency Centers - Waxahachie | unknown | — | `parse_error` |
+| 66 | Anaheim Global Medical Center | unknown | — | `parse_error` |
+| 320 | Annie Jeffrey Memorial County Health Center | unknown | — | `parse_error` |
+| 240 | Armstrong County Memorial Hospital | unknown | — | `parse_error` |
+| 414 | Ascension Alexian Brothers (Alexian Brothers Medical Center) | unknown | — | `parse_error` |
+| 81 | Ascension Alexian Brothers Rehabilitation Hospital (Alexian Brothers Medical Center) | unknown | — | `parse_error` |
+| 262 | Ascension All Saints Hospital - Spring Street Campus (Ascension All Saints Hospital, Inc.) | unknown | — | `mrf_download_error` |
+| 353 | Ascension All Saints Hospital - Wisconsin Avenue Campus (Ascension All Saints Hospital, Inc.) | unknown | — | `mrf_download_error` |
+| 381 | Ascension Borgess Allegan Hospital | unknown | — | `mrf_download_error` |
+| 17 | Ascension Borgess Allegan Hospital | unknown | — | `mrf_download_error` |
+| 287 | Ascension Borgess Hospital | unknown | — | `mrf_download_error` |
+| 358 | Ascension Borgess Hospital | unknown | — | `mrf_download_error` |
+| 499 | Ascension Borgess-Lee Hospital | unknown | — | `mrf_download_error` |
+| 276 | Ascension Borgess-Lee Hospital | unknown | — | `mrf_download_error` |
+| 576 | Ascension Borgess-Pipp Hospital (Ascension Borgess Hospital) | unknown | — | `mrf_download_error` |
+| 72 | Ascension Borgess-Pipp Hospital (Ascension Borgess Hospital) | unknown | — | `mrf_download_error` |
+| 2 | Ascension Borgess-Pipp Long-Term Acute Care Hospital (Ascension Borgess Hospital) | unknown | — | `mrf_download_error` |
+| 215 | Ascension Borgess-Pipp Long-Term Acute Care Hospital (Ascension Borgess Hospital) | unknown | — | `mrf_download_error` |
+| 102 | Ascension Brighton Center for Recovery | unknown | — | `mrf_download_error` |
+| 231 | Ascension Calumet Hospital, Inc. | unknown | — | `mrf_download_error` |
+| 265 | Ascension Columbia St. Mary's Hospital - Milwaukee Campus (Columbia St. Mary's Hospital Milwaukee, Inc.) | unknown | — | `mrf_download_error` |
+| 82 | Ascension Columbia St. Mary's Hospital - Ozaukee Campus (Columbia St. Mary's Hospital Milwaukee, Inc.) | unknown | — | `mrf_download_error` |
+| 350 | Ascension Columbia St. Mary's Hospital - Women's Medical Center (Columbia St. Mary's Hospital Milwaukee, Inc.) | unknown | — | `mrf_download_error` |
+| 246 | Ascension Genesys Hospital | unknown | — | `mrf_download_error` |
+| 566 | Ascension Holy Family (Presence Chicago Hospital Network) | unknown | — | `mrf_download_error` |
+| 529 | Ascension Macomb-Oakland Hospital, Madison Heights Campus | unknown | — | `mrf_download_error` |
+| 354 | Ascension Macomb-Oakland Hospital, Warren Campus | unknown | — | `mrf_download_error` |
+| 298 | Ascension Mercy (Presence Central and Suburban Hospitals Network) | unknown | — | `mrf_download_error` |
+| 67 | Ascension NE Wisconsin - Mercy Campus (Ascension NE Wisconsin, Inc.) | unknown | — | `mrf_download_error` |
+| 163 | Ascension NE Wisconsin - St. Elizabeth Campus (Ascension NE Wisconsin, Inc.) | unknown | — | `mrf_download_error` |
+| 93 | Ascension Providence | unknown | — | `mrf_download_error` |
+| 200 | Ascension Providence Hospital - Novi Campus | unknown | — | `mrf_download_error` |
+| 229 | Ascension Providence Hospital - Southfield Campus | unknown | — | `mrf_download_error` |
+| 492 | Ascension Providence Rochester Hospital | unknown | — | `mrf_download_error` |
+| 382 | Ascension Resurrection (Presence Chicago Hospital Network) | unknown | — | `mrf_download_error` |
+| 524 | Ascension River District Hospital | unknown | — | `mrf_download_error` |
+| 248 | Ascension SE Wisconsin Hospital - Elmbrook Campus | unknown | — | `mrf_download_error` |
+| 351 | Ascension SE Wisconsin Hospital - Franklin Campus | unknown | — | `mrf_download_error` |
+| 100 | Ascension SE Wisconsin Hospital - St. Joseph Campus | unknown | — | `mrf_download_error` |
+| 617 | Ascension Sacred Heart Bay (Bay County Health System, Inc.) | unknown | — | `mrf_download_error` |
+| 425 | Ascension Sacred Heart Emerald Coast (Sacred Heart Health System, Inc.) | unknown | — | `mrf_download_error` |
+| 144 | Ascension Sacred Heart Gulf (Sacred Heart Health System, Inc.) | unknown | — | `mrf_download_error` |
+| 471 | Ascension Sacred Heart Pensacola (Sacred Heart Health System, Inc.) | unknown | — | `mrf_download_error` |
+| 280 | Ascension Sacred Heart Rehabilitation Hospital (Sacred Heart Rehabilitation Institute, Inc.) | unknown | — | `mrf_download_error` |
+| 15 | Ascension Saint Agnes Hospital | unknown | — | `mrf_download_error` |
+| 405 | Ascension Saint Elizabeth (Presence Chicago Hospitals Network) | unknown | — | `mrf_download_error` |
+| 194 | Ascension Saint Francis (Presence Chicago Hospital Network) | unknown | — | `mrf_download_error` |
+| 369 | Ascension Saint Joseph - Chicago (Presence Chicago Hospital Network) | unknown | — | `mrf_download_error` |
+| 103 | Ascension Saint Joseph - Elgin (Presence Central and Suburban Hospitals Network) | unknown | — | `mrf_download_error` |
+| 299 | Ascension Saint Joseph - Joliet (Presence Central and Suburban Hospitals Network) | unknown | — | `mrf_download_error` |
+| 294 | Ascension Saint Mary - Chicago (Presence Chicago Hospital Network) | unknown | — | `mrf_download_error` |
+| 319 | Ascension Saint Mary - Kankakee (Presence Central and Suburban Hospitals Network) | unknown | — | `mrf_download_error` |
+| 5 | Ascension Saint Thomas DeKalb | unknown | — | `mrf_download_error` |
+| 52 | Ascension Saint Thomas Highlands | unknown | — | `mrf_download_error` |
+| 12 | Ascension Saint Thomas Midtown | unknown | — | `mrf_download_error` |
+| 406 | Ascension Saint Thomas River Park | unknown | — | `mrf_download_error` |
+| 191 | Ascension Saint Thomas Rutherford | unknown | — | `mrf_download_error` |
+| 31 | Ascension Saint Thomas Rutherford Westlawn | unknown | — | `mrf_download_error` |
+| 151 | Ascension Saint Thomas Stones River | unknown | — | `mrf_download_error` |
+| 337 | Ascension Saint Thomas Three Rivers | unknown | — | `mrf_download_error` |
+| 65 | Ascension Saint Thomas West | unknown | — | `mrf_download_error` |
+| 242 | Ascension Seton Bastrop (Ascension Seton) | unknown | — | `mrf_download_error` |
+| 408 | Ascension Seton Edgar B. Davis (Ascension Seton) | unknown | — | `mrf_download_error` |
+| 413 | Ascension Seton Hays (Ascension Seton) | unknown | — | `mrf_download_error` |
+| 153 | Ascension Seton Highland Lakes (Ascension Seton) | unknown | — | `mrf_download_error` |
+| 281 | Ascension Seton Medical Center Austin (Ascension Seton) | unknown | — | `mrf_download_error` |
+| 288 | Ascension Seton Northwest (Ascension Seton) | unknown | — | `mrf_download_error` |
+| 169 | Ascension Seton Shoal Creek (Ascension Seton) | unknown | — | `mrf_download_error` |
+| 445 | Ascension Seton Smithville (Ascension Seton) | unknown | — | `mrf_download_error` |
+| 553 | Ascension Seton Southwest (Ascension Seton) | unknown | — | `mrf_download_error` |
+| 269 | Ascension Seton Williamson (Ascension Seton) | unknown | — | `mrf_download_error` |
+| 120 | Ascension St. Francis Hospital, Inc. | unknown | — | `mrf_download_error` |
+| 247 | Ascension St. John Broken Arrow (St. John Broken Arrow, Inc.) | unknown | — | `mrf_download_error` |
+| 34 | Ascension St. John Children's Hospital | unknown | — | `mrf_download_error` |
+| 170 | Ascension St. John Hospital | unknown | — | `mrf_download_error` |
+| 411 | Ascension St. John Jane Phillips (Jane Phillips Memorial Medical Center, Inc.) | unknown | — | `mrf_download_error` |
+| 119 | Ascension St. John Medical Center (St. John Medical Center, Inc.) | unknown | — | `mrf_download_error` |
+| 143 | Ascension St. John Nowata (Jane Phillips Nowata Hospital, Inc.) | unknown | — | `mrf_download_error` |
+| 523 | Ascension St. John Owasso (Owasso Medical Facility, Inc.) | unknown | — | `mrf_download_error` |
+| 610 | Ascension St. John Sapulpa (St. John Sapulpa, Inc.) | unknown | — | `mrf_download_error` |
+| 172 | Ascension St. Vincent Anderson (St. Vincent Anderson Regional Hospital, Inc.) | unknown | — | `mrf_download_error` |
+| 344 | Ascension St. Vincent Carmel (St. Vincent Carmel Hospital, Inc.) | unknown | — | `mrf_download_error` |
+| 115 | Ascension St. Vincent Clay (St. Vincent Clay Hospital, Inc.) | unknown | — | `mrf_download_error` |
+| 137 | Ascension St. Vincent Evansville (St. Mary's Health, Inc.) | unknown | — | `mrf_download_error` |
+| 348 | Ascension St. Vincent Fishers (St. Vincent Fishers Hospital, Inc.) | unknown | — | `mrf_download_error` |
+| 237 | Ascension St. Vincent Heart Center (St. Vincent Heart Center of Indiana, LLC) | unknown | — | `mrf_download_error` |
+| 171 | Ascension St. Vincent Hospital - Avon  (St Vincent Hospital and Health Care Center Inc.) | unknown | — | `mrf_download_error` |
+| 175 | Ascension St. Vincent Hospital - Castleton  (St Vincent Hospital and Health Care Center Inc.) | unknown | — | `mrf_download_error` |
+| 473 | Ascension St. Vincent Hospital - Indianapolis  (St Vincent Hospital and Health Care Center Inc.) | unknown | — | `mrf_download_error` |
+| 135 | Ascension St. Vincent Hospital - Indianapolis South  (St Vincent Hospital and Health Care Center Inc.) | unknown | — | `mrf_download_error` |
+| 394 | Ascension St. Vincent Hospital - Plainfield  (St Vincent Hospital and Health Care Center Inc.) | unknown | — | `mrf_download_error` |
+| 452 | Ascension St. Vincent Jennings (St. Vincent Jennings Hospital, Inc.) | unknown | — | `mrf_download_error` |
+| 611 | Ascension St. Vincent Kokomo (St. Joseph Hospital & Health Center, Inc.) | unknown | — | `mrf_download_error` |
+| 393 | Ascension St. Vincent Mercy (St. Vincent Madison County Health System, Inc.) | unknown | — | `mrf_download_error` |
+| 213 | Ascension St. Vincent Orthopedic Hospital (St. Mary's Health, Inc.) | unknown | — | `mrf_download_error` |
+| 336 | Ascension St. Vincent Randolph (St. Vincent Randolph Hospital, Inc.) | unknown | — | `mrf_download_error` |
+| 379 | Ascension St. Vincent Salem (St. Vincent Salem Hospital, Inc.) | unknown | — | `mrf_download_error` |
+| 249 | Ascension St. Vincent Seton (St. Vincent Seton Specialty Hospital, Inc.) | unknown | — | `mrf_download_error` |
+| 314 | Ascension St. Vincent Stress Center  (St Vincent Hospital and Health Care Center Inc.) | unknown | — | `mrf_download_error` |
+| 53 | Ascension St. Vincent Warrick (St. Mary's Warrick Hospital, Inc.) | unknown | — | `mrf_download_error` |
+| 607 | Ascension St. Vincent Williamsport (St. Vincent Williamsport Hospital, Inc.) | unknown | — | `mrf_download_error` |
+| 155 | Ascension St. Vincent Women's Hospital  (St Vincent Hospital and Health Care Center Inc.) | unknown | — | `mrf_download_error` |
+| 574 | Ascension St. Vincent's Clay County (St. Vincent's Medical Center, Inc.) | unknown | — | `mrf_download_error` |
+| 113 | Ascension St. Vincent's Riverside (St. Vincent's Medical Center, Inc.) | unknown | — | `mrf_download_error` |
+| 254 | Ascension St. Vincent's Southside (St. Luke's-St. Vincent's HealthCare, Inc.) | unknown | — | `mrf_download_error` |
+| 579 | Ascension St. Vincent's St. Johns County (St. Vincent's Health System, Inc.) | unknown | — | `mrf_download_error` |
+| 476 | Ascension Via Christi Hospital Manhattan, Inc | unknown | — | `mrf_download_error` |
+| 97 | Ascension Via Christi Hospital Pittsburg, Inc. | unknown | — | `mrf_download_error` |
+| 180 | Ascension Via Christi Hospital St. Teresa, Inc. | unknown | — | `mrf_download_error` |
+| 253 | Ascension Via Christi Rehabilitation Hospital, Inc. | unknown | — | `mrf_download_error` |
+| 158 | Ascension Via Christi St. Francis (Ascension Via Christi Hospitals Wichita, Inc.) | unknown | — | `mrf_download_error` |
+| 208 | Ascension Via Christi St. Joseph (Ascension Via Christi Hospitals Wichita, Inc.) | unknown | — | `mrf_download_error` |
+| 563 | Baptist & Wolfson Oakleaf Emergency Room | unknown | — | `parse_error` |
+| 561 | Baptist Health Deaconess Madisonville, Inc | unknown | — | `mrf_download_error` |
+| 179 | Baptist Health Hospital Doral | unknown | — | `parse_error` |
+| 51 | Baptist Hospital | unknown | — | `parse_error` |
+| 441 | Bariatric Center Lenexa | unknown | — | `mrf_download_error` |
+| 157 | Barnes Jewish Hospital | unknown | — | `parse_error` |
+| 564 | Barnes Jewish West County Hospital | unknown | — | `parse_error` |
+| 19 | Bates County Memorial Hospital | unknown | — | `mrf_download_error` |
+| 578 | Bayonne Medical Center | unknown | — | `parse_error` |
+| 544 | Beauregard Health System | unknown | — | `parse_error` |
+| 245 | Bethesda Hospital East | unknown | — | `parse_error` |
+| 260 | Bethesda Hospital West | unknown | — | `parse_error` |
+| 467 | Big South Fork Medical Center | unknown | — | `mrf_download_error` |
+| 183 | Bitterroot Health | unknown | — | `parse_error` |
+| 509 | Blackberry Center | unknown | — | `parse_error` |
+| 75 | Boca Raton Regional Hospital | unknown | — | `parse_error` |
+| 399 | Boston Medical Center | unknown | — | `parse_error` |
+| 508 | Bothwell Regional Health Center | unknown | — | `parse_error` |
+| 256 | Bowen Health, Inc. | unknown | — | `parse_error` |
+| 192 | Box Butte General Hospital | unknown | — | `parse_error` |
+| 614 | Brentwood Meadows LLC | unknown | — | `mrf_download_error` |
+| 601 | Bridgeport Hospital | unknown | — | `parse_error` |
+| 567 | Brookings Hospital | unknown | — | `parse_error` |
+| 620 | Brooks Rehabilitation Hospital – Bartram Campus | unknown | — | `parse_error` |
+| 541 | Brooks Rehabilitation Hospital – University Campus | unknown | — | `parse_error` |
+| 464 | Buchanan County Health Center | unknown | — | `parse_error` |
+| 150 | Bullock County Rural Emergency Hospital | unknown | — | `parse_error` |
+| 10 | CENTENNIAL MEDICAL CENTER | unknown | — | `mrf_download_error` |
+| 496 | CHESHIRE MEDICAL CENTER | unknown | — | `mrf_download_error` |
+| 519 | CJW - JOHNSTON WILLIS CAMPUS | unknown | — | `mrf_download_error` |
+| 25 | CJW Medical Center-Chippenham Hospital Campus | unknown | — | `mrf_download_error` |
+| 582 | Cabell Huntington Hospital | unknown | — | `mrf_download_error` |
+| 293 | Caldwell Medical Center | unknown | — | `mrf_download_error` |
+| 357 | Caldwell Regional Medical Center | unknown | — | `parse_error` |
+| 494 | Calvert Health | unknown | — | `mrf_download_error` |
+| 94 | Cambridge Health Alliance | unknown | — | `parse_error` |
+| 335 | Cameron Regional Medical Center | unknown | — | `mrf_download_error` |
+| 581 | Canonsburg General Hospital | unknown | — | `mrf_download_error` |
+| 562 | CareWell Health | unknown | — | `parse_error` |
+| 7 | Carrus Behavioral Hospital | unknown | — | `parse_error` |
+| 341 | Carrus Rehabilitation Hospital | unknown | — | `parse_error` |
+| 370 | Casa Colina Hospital and Centers for Healthcare | unknown | — | `mrf_download_error` |
+| 472 | Cedar Crest Hospital & Residential Treatment Center | unknown | — | `mrf_download_error` |
+| 36 | Center for Digestive Health, LLC | unknown | — | `mrf_download_error` |
+| 439 | CenterPointe Hospital | unknown | — | `mrf_download_error` |
+| 188 | Central Indiana-AMG Specialty Hospital | unknown | — | `parse_error` |
+| 313 | Central WA Hospital & Clinics | unknown | — | `parse_error` |
+| 184 | Chapman Global Medical Center | unknown | — | `parse_error` |
+| 546 | Chicago Behavioral Hospital | unknown | — | `parse_error` |
+| 537 | Children's Healthcare of Atlanta at Arthur M. Blank | unknown | — | `mrf_download_error` |
+| 434 | Children's Healthcare of Atlanta at Hughes Spalding | unknown | — | `mrf_download_error` |
+| 317 | Children's Healthcare of Atlanta at Scottish Rite | unknown | — | `mrf_download_error` |
+| 371 | Children's Hospital New Orleans | unknown | — | `parse_error` |
+| 63 | Children’s Medical Center Dallas | unknown | — | `parse_error` |
+| 474 | Children’s Medical Center Plano | unknown | — | `parse_error` |
+| 255 | Chris Kyle Patriots Hospital | unknown | — | `parse_error` |
+| 284 | Christ Hospital | unknown | — | `parse_error` |
+| 133 | ClearSky Rehabilitation Hospital of Flower Mound | unknown | — | `parse_error` |
+| 450 | Coal County General Hospital | unknown | — | `parse_error` |
+| 123 | Coffeyville Regional Medical Center | unknown | — | `mrf_download_error` |
+| 387 | Columbus Specialty Hospital | unknown | — | `mrf_download_error` |
+| 338 | Concho County Hospital | unknown | — | `parse_error` |
+| 552 | Cook Hospital | unknown | — | `mrf_download_error` |
+| 48 | Copiah County Medical Center | unknown | — | `parse_error` |
+| 152 | Copper Hills Youth Center | unknown | — | `parse_error` |
+| 209 | Cornerstone Specialty Hospitals Shawnee | unknown | — | `parse_error` |
+| 296 | Covington-AMG Physical Rehabilitation Hospital | unknown | — | `parse_error` |
+| 321 | DEL SOL MEDICAL CENTER | unknown | — | `mrf_download_error` |
+| 438 | Dameron Hospital | unknown | — | `parse_error` |
+| 482 | Davis Medical Center | unknown | — | `mrf_download_error` |
+| 318 | Day Kimball Healthcare | unknown | — | `parse_error` |
+| 455 | Dayton General Hospital | unknown | — | `parse_error` |
+| 224 | Deaconess Illinois Red Bud Regional Hospital | unknown | — | `parse_error` |
+| 214 | Dell Children's Medical Center (Ascension Seton) | unknown | — | `mrf_download_error` |
+| 556 | Dell Children's Medical Center North Campus (Ascension Seton) | unknown | — | `mrf_download_error` |
+| 429 | Dell Seton Medical Center at The University of Texas (Ascension Seton) | unknown | — | `mrf_download_error` |
+| 225 | Delta Health System | unknown | — | `parse_error` |
+| 378 | Doctors Hospital | unknown | — | `parse_error` |
+| 279 | Dorminy Medical Center | unknown | — | `parse_error` |
+| 161 | Drumright Regional Hospital | unknown | — | `parse_error` |
+| 447 | ERLC, LLC d/b/a Elitecare Emergency Hospital | unknown | — | `parse_error` |
+| 586 | East Jefferson General Hospital | unknown | — | `parse_error` |
+| 366 | Eastern Oklahoma Medical Center | unknown | — | `mrf_download_error` |
+| 187 | Ed Fraser Memorial Hospital | unknown | — | `mrf_download_error` |
+| 419 | Ellett Memorial Hospital | unknown | — | `mrf_download_error` |
+| 535 | Ely Bloomenson Community Hospital | unknown | — | `mrf_download_error` |
+| 575 | Eminent Medical Center | unknown | — | `parse_error` |
+| 24 | Evergreen Medical Center | unknown | — | `mrf_download_error` |
+| 216 | Exeter Hospital | unknown | — | `mrf_download_error` |
+| 177 | Fairview Bethesda Hospital | unknown | — | `parse_error` |
+| 420 | Fairview Bethesda Hospital | unknown | — | `parse_error` |
+| 32 | Fairview Bethesda Hospital | unknown | — | `parse_error` |
+| 368 | Family Health West Hospital | unknown | — | `parse_error` |
+| 239 | First Care Health Center | unknown | — | `parse_error` |
+| 385 | Fishermens Community Hospital | unknown | — | `parse_error` |
+| 572 | Forbes Hospital | unknown | — | `mrf_download_error` |
+| 166 | Freedom Behavioral Hospital Of Monroe | unknown | — | `parse_error` |
+| 468 | Freedom Behavioral Hospital Of Plainview | unknown | — | `parse_error` |
+| 483 | Freeman Fort Scott Hospital Acute Inpatient Hospital | unknown | — | `parse_error` |
+| 423 | Freeman Hospital East Campus Acute Rehab | unknown | — | `parse_error` |
+| 559 | Freeman Hospital East Campus Inpatient Geri Psych | unknown | — | `parse_error` |
+| 558 | Freeman Hospital East Campus Inpatient Psych | unknown | — | `parse_error` |
+| 1 | Freeman Hospital West Campus Acute Inpatient Hospital | unknown | — | `parse_error` |
+| 160 | Freeman Neosho Hospital Inpatient Critical Access | unknown | — | `parse_error` |
+| 122 | Freeman Neosho Hospital Inpatient Swing Bed | unknown | — | `parse_error` |
+| 112 | Geisinger Bloomsburg Hospital | unknown | — | `parse_error` |
+| 360 | Geisinger Community Medical Center | unknown | — | `parse_error` |
+| 417 | Geisinger Jersey Shore Hospital | unknown | — | `parse_error` |
+| 227 | Geisinger Lewistown Hospital | unknown | — | `parse_error` |
+| 263 | Geisinger Medical Center | unknown | — | `mrf_download_error` |
+| 283 | Geisinger Medical Center Muncy | unknown | — | `mrf_download_error` |
+| 189 | Geisinger Shamokin Area Community Hospital | unknown | — | `mrf_download_error` |
+| 555 | Geisinger Wyoming Valley | unknown | — | `parse_error` |
+| 372 | Golden Plains Community Hospital | unknown | — | `parse_error` |
+| 308 | Gove County Medical Center | unknown | — | `parse_error` |
+| 391 | Grady Health System | unknown | — | `mrf_download_error` |
+| 531 | Grand Itasca Clinic and Hospital | unknown | — | `parse_error` |
+| 275 | Grand Itasca Clinic and Hospital | unknown | — | `parse_error` |
+| 538 | Great River Medical Center | unknown | — | `parse_error` |
+| 365 | Greene County Medical Center | unknown | — | `parse_error` |
+| 266 | Greenwich Hospital | unknown | — | `parse_error` |
+| 139 | Grove Center Medical Center | unknown | — | `mrf_download_error` |
+| 233 | Grove Hill Memorial hospital | unknown | — | `parse_error` |
+| 373 | HANOVER EMERGENCY CENTER | unknown | — | `mrf_download_error` |
+| 465 | HCA FLORIDA LEHIGH HOSPITAL | unknown | — | `mrf_download_error` |
+| 322 | HCA HEALTHCARE BRIGHTON PARK ER | unknown | — | `mrf_download_error` |
+| 182 | HCA HEALTHCARE CENTRE POINTE ER | unknown | — | `mrf_download_error` |
+| 600 | HCA HEALTHCARE JAMES ISLAND ER | unknown | — | `mrf_download_error` |
+| 501 | HCA HEALTHCARE MONCKS CORNER ER | unknown | — | `mrf_download_error` |
+| 226 | HCA HEALTHCARE SUMMERVILLE HOSPITAL | unknown | — | `mrf_download_error` |
+| 495 | HCA HEALTHCARE TRIDENT HOSPITAL | unknown | — | `mrf_download_error` |
+| 306 | HCA HOUSTON ER 24/7 FALLBROOK | unknown | — | `mrf_download_error` |
+| 533 | HCA HOUSTON ER 24/7 SPRING | unknown | — | `mrf_download_error` |
+| 79 | HCA HealthONE SOUTHWEST ER, A PART OF SWEDISH | unknown | — | `mrf_download_error` |
+| 178 | HENRICO DOCTORS HOSPITAL | unknown | — | `mrf_download_error` |
+| 584 | HOLY CROSS HOSPITAL | unknown | — | `mrf_download_error` |
+| 211 | HSHS Good Shepherd Hospital | unknown | — | `mrf_download_error` |
+| 618 | HSHS St. John's Hospital | unknown | — | `mrf_download_error` |
+| 73 | HSS Brooklyn Outpatient Center | unknown | — | `mrf_download_error` |
+| 46 | HSS East Side Outpatient Center | unknown | — | `mrf_download_error` |
+| 241 | HSS Hudson Yards Outpatient Center | unknown | — | `mrf_download_error` |
+| 223 | HSS Long Island Outpatient Center | unknown | — | `mrf_download_error` |
+| 590 | HSS Midtown Outpatient Center | unknown | — | `mrf_download_error` |
+| 593 | HSS Paramus Midland Outpatient Center | unknown | — | `mrf_download_error` |
+| 418 | HSS Paramus Outpatient Center | unknown | — | `mrf_download_error` |
+| 185 | HSS Queens Outpatient Center | unknown | — | `mrf_download_error` |
+| 427 | HSS Southampton Outpatient Center | unknown | — | `mrf_download_error` |
+| 568 | HSS Stamford Outpatient Center | unknown | — | `mrf_download_error` |
+| 86 | HSS West Side Outpatient Center | unknown | — | `mrf_download_error` |
+| 573 | HSS Westchester Outpatient Center | unknown | — | `mrf_download_error` |
+| 57 | Halifax Health \| Brooks Rehabilitation – Center for Inpatient Rehabilitation | unknown | — | `parse_error` |
+| 532 | Hansen Family Hospital - Iowa Falls, IA | unknown | — | `parse_error` |
+| 380 | Harmon Memorial Hospital | unknown | — | `parse_error` |
+| 154 | Harney District Hospital | unknown | — | `mrf_download_error` |
+| 142 | Harrisburg Medical Center | unknown | — | `mrf_download_error` |
+| 126 | HealthEast St. John's Hospital | unknown | — | `parse_error` |
+| 506 | HealthEast St. John's Hospital | unknown | — | `parse_error` |
+| 108 | HealthEast St. John's Hospital | unknown | — | `parse_error` |
+| 521 | HealthEast Woodwinds Hospital | unknown | — | `parse_error` |
+| 480 | HealthEast Woodwinds Hospital | unknown | — | `parse_error` |
+| 289 | HealthEast Woodwinds Hospital | unknown | — | `parse_error` |
+| 604 | Hemet Global Medical Center | unknown | — | `parse_error` |
+| 602 | Hemet Global Medical Center | unknown | — | `parse_error` |
+| 603 | Herrin Hospital | unknown | — | `mrf_download_error` |
+| 539 | Highlands Medical Center | unknown | — | `parse_error` |
+| 440 | Hillsboro Community Hospital | unknown | — | `parse_error` |
+| 295 | Hillsboro Medical Center | unknown | — | `parse_error` |
+| 141 | Hillsdale Community Health Center | unknown | — | `mrf_download_error` |
+| 424 | Hoboken University Medical Center | unknown | — | `parse_error` |
+| 543 | Holy Cross Health Germantown | unknown | — | `parse_error` |
+| 547 | Holy Cross Health Silver Spring | unknown | — | `parse_error` |
+| 437 | Holy Name Medical Center | unknown | — | `mrf_download_error` |
+| 290 | Homestead Hospital | unknown | — | `parse_error` |
+| 257 | Hopedale Medical Complex | unknown | — | `parse_error` |
+| 339 | Hospital for Behavioral Medicine | unknown | — | `parse_error` |
+| 517 | Hospital for Special Surgery Main Hospital | unknown | — | `mrf_download_error` |
+| 156 | Houma-AMG Specialty Hospital | unknown | — | `parse_error` |
+| 560 | Huntington Hospital | unknown | — | `mrf_download_error` |
+| 432 | Huron Regional Medical Center | unknown | — | `mrf_download_error` |
+| 205 | Imaging Center Gloster Creek Village, PLLC | unknown | — | `mrf_download_error` |
+| 272 | Iredell Davis Behavioral Health Hospital | unknown | — | `parse_error` |
+| 491 | Iredell Memorial Hospital | unknown | — | `parse_error` |
+| 33 | Izard Regional Hospital LLC | unknown | — | `mrf_download_error` |
+| 303 | Jack Hughston Memorial Hospital | unknown | — | `mrf_download_error` |
+| 343 | Jackson County Memorial Hospital | unknown | — | `parse_error` |
+| 332 | Jackson County Regional Health Center | unknown | — | `parse_error` |
+| 331 | Jefferson Regional Medical Center | unknown | — | `mrf_download_error` |
+| 515 | Jennie Stuart Medical Center | unknown | — | `mrf_download_error` |
+| 456 | Jupiter Medical Center | unknown | — | `parse_error` |
+| 285 | K. Hovnanian Children's Hospital | unknown | — | `parse_error` |
+| 105 | Kahuku Medical Center | unknown | — | `parse_error` |
+| 74 | Kern Medical Center | unknown | — | `mrf_download_error` |
+| 376 | LAS PALMAS DEL SOL EMERGENCY CENTER EAST | unknown | — | `mrf_download_error` |
+| 388 | LAS PALMAS DEL SOL HEALTHCARE HORIZON (ER) | unknown | — | `mrf_download_error` |
+| 580 | LECOM Medical Center | unknown | — | `mrf_download_error` |
+| 407 | La Amistad Behavioral Health Services | unknown | — | `parse_error` |
+| 116 | La Casa Psychiatric Health Facility | unknown | — | `parse_error` |
+| 410 | Lackey Memorial Hospital | unknown | — | `mrf_download_error` |
+| 129 | Lafayette Physical Rehabilitation Hospital | unknown | — | `parse_error` |
+| 412 | Lafayette-AMG Specialty Hospital | unknown | — | `parse_error` |
+| 176 | Lake Behavioral Hospital | unknown | — | `parse_error` |
+| 220 | Lake Regional Health System | unknown | — | `mrf_download_error` |
+| 362 | Lakeland Behavioral Health System | unknown | — | `mrf_download_error` |
+| 202 | Las Vegas-AMG Specialty Hospital | unknown | — | `parse_error` |
+| 346 | Lauderdale Community Hospital | unknown | — | `parse_error` |
+| 124 | Lawrence + Memorial Hospital | unknown | — | `parse_error` |
+| 111 | Legacy Unity Center for Behavioral Health PES | unknown | — | `parse_error` |
+| 244 | Lincoln County Hospital District | unknown | — | `mrf_download_error` |
+| 549 | Little River Medical Center, INC DBA Little River Memorial Hospital | unknown | — | `mrf_download_error` |
+| 400 | Livingston HealthCare | unknown | — | `parse_error` |
+| 11 | Loretto Hospital | unknown | — | `parse_error` |
+| 44 | M Health Fairview Lakes Hospital | unknown | — | `parse_error` |
+| 449 | M Health Fairview Lakes Medical Center | unknown | — | `parse_error` |
+| 173 | M Health Fairview Lakes Medical Center | unknown | — | `parse_error` |
+| 512 | M Health Fairview Maple Grove Surgery Center | unknown | — | `parse_error` |
+| 222 | M Health Fairview Maple Grove Surgery Center | unknown | — | `parse_error` |
+| 43 | M Health Fairview Maple Grove Surgery Center | unknown | — | `parse_error` |
+| 117 | M Health Fairview Northland Medical | unknown | — | `parse_error` |
+| 234 | M Health Fairview Northland Medical Center | unknown | — | `parse_error` |
+| 85 | M Health Fairview Northland Medical Center | unknown | — | `parse_error` |
+| 389 | M Health Fairview Ridges Hospital | unknown | — | `parse_error` |
+| 190 | M Health Fairview Ridges Hospital | unknown | — | `parse_error` |
+| 20 | M Health Fairview Ridges Hospital | unknown | — | `parse_error` |
+| 416 | M Health Fairview Southdale Hospital | unknown | — | `parse_error` |
+| 518 | M Health Fairview Southdale Hospital | unknown | — | `parse_error` |
+| 9 | M Health Fairview Southdale Hospital | unknown | — | `parse_error` |
+| 396 | M Health Fairview University of Minnesota Masonic Children's Hospital | unknown | — | `parse_error` |
+| 109 | M Health Fairview University of Minnesota Masonic Children's Hospital | unknown | — | `parse_error` |
+| 55 | M Health Fairview University of Minnesota Masonic Children's Hospital | unknown | — | `parse_error` |
+| 186 | M Health Fairview University of Minnesota Medical Center | unknown | — | `parse_error` |
+| 457 | M Health Fairview University of Minnesota Medical Center | unknown | — | `parse_error` |
+| 121 | M Health Fairview University of Minnesota Medical Center | unknown | — | `parse_error` |
+| 327 | MEDICAL CITY CHILDREN'S HOSPITAL | unknown | — | `mrf_download_error` |
+| 274 | MEDICAL CITY DALLAS HOSPITAL | unknown | — | `mrf_download_error` |
+| 328 | MEDICAL CITY ER GARLAND | unknown | — | `mrf_download_error` |
+| 3 | MISSION HOSPITAL | unknown | — | `mrf_download_error` |
+| 221 | MISSION MAMA | unknown | — | `mrf_download_error` |
+| 435 | MOUNT SINAI HOSPITAL MEDICAL CENTER | unknown | — | `mrf_download_error` |
+| 278 | MOUNTAIN COMMUNITIES HEALTHCARE DISTRICT | unknown | — | `mrf_download_error` |
+| 130 | MUSC Health Orangeburg | unknown | — | `mrf_download_error` |
+| 498 | Madison Health | unknown | — | `parse_error` |
+| 415 | Magnolia Regional Medical Center | unknown | — | `parse_error` |
+| 421 | Mariners Hospital | unknown | — | `parse_error` |
+| 615 | Mary Rutan Health | unknown | — | `mrf_download_error` |
+| 128 | McCurtain Memorial Hospital | unknown | — | `mrf_download_error` |
+| 390 | MeadowWood Behavioral Health Hospital | unknown | — | `mrf_download_error` |
+| 297 | MedStar Health Physical Therapy at Irving Street-Neurorehabilitation Center | unknown | — | `parse_error` |
+| 475 | Medical Arts Hospital | unknown | — | `parse_error` |
+| 401 | Mee Memorial Hospital | unknown | — | `mrf_download_error` |
+| 181 | Memorial Hermann Imaging Center (All Centers Except Bellaire/Cypress/Texas Medical Center/Upper Kirby) | unknown | — | `mrf_download_error` |
+| 27 | Memorial Hospital | unknown | — | `mrf_download_error` |
+| 488 | Memorial Hospital of Carbondale | unknown | — | `mrf_download_error` |
+| 613 | Menifee Global Medical Center | unknown | — | `parse_error` |
+| 91 | Methodist Women's Hosptial | unknown | — | `parse_error` |
+| 140 | Midland County Hospital District | unknown | — | `mrf_download_error` |
+| 591 | Midland Memorial Hospital | unknown | — | `mrf_download_error` |
+| 426 | Midwest Orthopedic Specialty Hospital | unknown | — | `mrf_download_error` |
+| 520 | Milford Hospital | unknown | — | `parse_error` |
+| 18 | Mineral Community Hospital | unknown | — | `parse_error` |
+| 355 | Minidoka Memorial Hospital | unknown | — | `mrf_download_error` |
+| 409 | Missouri Baptist Medical Center | unknown | — | `parse_error` |
+| 461 | Missouri Delta Medical Center | unknown | — | `mrf_download_error` |
+| 311 | Mon Health Marion Neighborhood Hospital | unknown | — | `mrf_download_error` |
+| 21 | Munising Memorial Hospital | unknown | — | `parse_error` |
+| 315 | NW Indiana-AMG Specialty Hospital | unknown | — | `parse_error` |
+| 8 | NYU Langone Hospital - Brooklyn | unknown | — | `parse_error` |
+| 49 | NYU Langone Hospital - Long Island | unknown | — | `parse_error` |
+| 436 | NYU Langone Orthopedic Hospital | unknown | — | `parse_error` |
+| 148 | NYU Langone Tisch Hospital | unknown | — | `parse_error` |
+| 363 | Nebraska Methodist Hospital | unknown | — | `parse_error` |
+| 550 | New Orleans East Hospital | unknown | — | `parse_error` |
+| 460 | Newberry County Memorial Hospital | unknown | — | `mrf_download_error` |
+| 204 | North MS Ambulatory Surgery Center, LLC | unknown | — | `mrf_download_error` |
+| 522 | North Mississippi Specialty Hospital | unknown | — | `parse_error` |
+| 58 | North Tampa Behavioral Health Hospital | unknown | — | `mrf_download_error` |
+| 585 | Northeast Rehabilitation Hospital | unknown | — | `mrf_download_error` |
+| 551 | Northern Light Inland Hospital | unknown | — | `mrf_download_error` |
+| 165 | Northern Light Mayo Hospital | unknown | — | `parse_error` |
+| 228 | Northside Hospital Gwinnett | unknown | — | `mrf_download_error` |
+| 583 | Northwest Community Hospital | unknown | — | `mrf_download_error` |
+| 89 | Northwestern Medical Center | unknown | — | `parse_error` |
+| 606 | Northwestern Medicine Central DuPage Hospital | unknown | — | `mrf_download_error` |
+| 134 | Northwestern Medicine Delnor Hospital | unknown | — | `mrf_download_error` |
+| 516 | Northwestern Medicine Kishwaukee Hospital | unknown | — | `mrf_download_error` |
+| 485 | Northwestern Medicine Lake Forest Hospital | unknown | — | `mrf_download_error` |
+| 514 | Northwestern Medicine Marianjoy Rehabilitation Hospital | unknown | — | `mrf_download_error` |
+| 333 | Northwestern Medicine McHenry Hospital | unknown | — | `mrf_download_error` |
+| 70 | Northwestern Medicine Palos Hospital | unknown | — | `mrf_download_error` |
+| 127 | Northwestern Medicine Valley West Hospital | unknown | — | `mrf_download_error` |
+| 174 | Northwestern Memorial Hospital | unknown | — | `mrf_download_error` |
+| 329 | Norton Children's Hospital | unknown | — | `parse_error` |
+| 536 | Norton County Hospital | unknown | — | `parse_error` |
+| 95 | OKC-AMG Specialty Hospital | unknown | — | `parse_error` |
+| 132 | OSS Health | unknown | — | `parse_error` |
+| 292 | Oasis Behavioral Health Hospital | unknown | — | `mrf_download_error` |
+| 312 | Oceans Behavioral Hospital Alexandria | unknown | — | `parse_error` |
+| 503 | Ochiltree General Hospital | unknown | — | `mrf_download_error` |
+| 118 | Ochsner Baptist | unknown | — | `mrf_download_error` |
+| 334 | Ochsner Hospital for Orthopedics and Sports Medicine | unknown | — | `mrf_download_error` |
+| 136 | Ochsner Medical Center - Jefferson Highway | unknown | — | `mrf_download_error` |
+| 497 | Ochsner Medical Center - West Bank Campus | unknown | — | `mrf_download_error` |
+| 164 | Onslow Memorial Hospital, Inc. | unknown | — | `mrf_download_error` |
+| 609 | Orthopaedic Hospital of Wisconsin, LLC | unknown | — | `mrf_download_error` |
+| 596 | PARHAM DOCTORS HOSPITAL | unknown | — | `mrf_download_error` |
+| 433 | Palo Pinto General Hospital | unknown | — | `parse_error` |
+| 16 | Park Royal Hospital | unknown | — | `mrf_download_error` |
+| 477 | Parkside Psychiatric Hospital | unknown | — | `parse_error` |
+| 273 | Peyton Manning Children's Hospital at Ascension St. Vincent  (St Vincent Hospital and Health Care Center Inc.) | unknown | — | `mrf_download_error` |
+| 219 | Piedmont Henry | unknown | — | `mrf_download_error` |
+| 487 | Piedmont McDuffie | unknown | — | `parse_error` |
+| 302 | Piedmont Mountainside | unknown | — | `mrf_download_error` |
+| 330 | Pontiac General Hospital | unknown | — | `mrf_download_error` |
+| 14 | Port St Lucie Hospital | unknown | — | `parse_error` |
+| 218 | Prisma Health Baptist Easley Hospital | unknown | — | `parse_error` |
+| 462 | Prisma Health Baptist Hospital | unknown | — | `parse_error` |
+| 50 | Prisma Health Baptist Parkridge Hospital | unknown | — | `parse_error` |
+| 78 | Prisma Health Greenville Memorial Hospital | unknown | — | `parse_error` |
+| 565 | Prisma Health Greer Memorial Hospital | unknown | — | `parse_error` |
+| 356 | Prisma Health Hillcrest Memorial Hospital | unknown | — | `parse_error` |
+| 534 | Prisma Health Laurens County Hospital | unknown | — | `parse_error` |
+| 270 | Prisma Health North Greenville Hospital | unknown | — | `parse_error` |
+| 47 | Prisma Health Oconee Memorial Hospital | unknown | — | `parse_error` |
+| 323 | Prisma Health Patewood Memorial Hospital | unknown | — | `parse_error` |
+| 29 | Prisma Health Richland Hospital | unknown | — | `parse_error` |
+| 145 | Prisma Health Tuomey Hospital | unknown | — | `parse_error` |
+| 42 | ProMedica Flower Hospital | unknown | — | `mrf_download_error` |
+| 345 | ProMedica Russell J. Ebeid Children's Hospital | unknown | — | `mrf_download_error` |
+| 162 | ProMedica Toledo Hospital | unknown | — | `mrf_download_error` |
+| 340 | ProMedica Wildwood Orthopaedic and Spine Hospital | unknown | — | `mrf_download_error` |
+| 505 | Progress West Hospital | unknown | — | `parse_error` |
+| 402 | Psychiatric Care at Delmar Campus | unknown | — | `parse_error` |
+| 444 | Punxsutawney Area Hospital | unknown | — | `parse_error` |
+| 22 | RETREAT HOSPITAL | unknown | — | `mrf_download_error` |
+| 493 | RML Specialty Hospital Chicago | unknown | — | `parse_error` |
+| 513 | RML Specialty Hospital Hinsdale | unknown | — | `parse_error` |
+| 26 | Randolph Health | unknown | — | `mrf_download_error` |
+| 305 | Range Regional Health Services | unknown | — | `parse_error` |
+| 466 | Ray County Hospital and Healthcare | unknown | — | `parse_error` |
+| 342 | Redeemer Health | unknown | — | `parse_error` |
+| 398 | Rehabilitation Institute of Chicago d/b/a Shirley Ryan Abilitylab | unknown | — | `mrf_download_error` |
+| 384 | Resurrection Medical Center | unknown | — | `mrf_download_error` |
+| 374 | Rhea Medical Center | unknown | — | `mrf_download_error` |
+| 595 | Rice County District Hospital | unknown | — | `parse_error` |
+| 422 | Ridgeview Behavioral Hospital | unknown | — | `parse_error` |
+| 504 | Ridgeview Institute of Monroe | unknown | — | `parse_error` |
+| 324 | Ridgeview Institute of Smyrna | unknown | — | `parse_error` |
+| 616 | River Place Behavioral Health Hospital | unknown | — | `mrf_download_error` |
+| 347 | River's Edge Hospital | unknown | — | `mrf_download_error` |
+| 13 | Riverside Medical Center | unknown | — | `parse_error` |
+| 489 | Riverside Medical Center | unknown | — | `parse_error` |
+| 526 | Riverview Behavioral Health Hospital | unknown | — | `mrf_download_error` |
+| 235 | Rogers Memorial Hospital | unknown | — | `mrf_download_error` |
+| 554 | Rolling Hills Hospital | unknown | — | `mrf_download_error` |
+| 23 | Russell Regional Hospital | unknown | — | `mrf_download_error` |
+| 325 | SCHWAB REHAB HOSPITAL AND CARE NETWORK | unknown | — | `mrf_download_error` |
+| 236 | SMC Family Medicine | unknown | — | `mrf_download_error` |
+| 470 | STAT Emergency Center – Laredo South | unknown | — | `parse_error` |
+| 107 | STAT Specialty Hospital – Del Rio | unknown | — | `parse_error` |
+| 352 | STAT Specialty Hospital – Eagle Pass | unknown | — | `parse_error` |
+| 383 | STAT Specialty Hospital – Laredo North | unknown | — | `parse_error` |
+| 4 | SWIFT CREEK ER | unknown | — | `mrf_download_error` |
+| 59 | Sage Rehab Hospital | unknown | — | `parse_error` |
+| 146 | Sage Rehab Hospital | unknown | — | `parse_error` |
+| 510 | Saint Vincent Hospital | unknown | — | `mrf_download_error` |
+| 41 | Salinas Valley Memorial Healthcare System | unknown | — | `parse_error` |
+| 525 | Samaritan Medical Center | unknown | — | `mrf_download_error` |
+| 6 | San Juan Regional Medical Center | unknown | — | `parse_error` |
+| 92 | SandyPines Residential Treatment Center | unknown | — | `parse_error` |
+| 60 | Santa Clara Valley Medical Center | unknown | — | `mrf_download_error` |
+| 83 | Schuyler County Hospital District | unknown | — | `parse_error` |
+| 530 | Scotland County Hospital | unknown | — | `mrf_download_error` |
+| 463 | Scripps Green Hospital | unknown | — | `mrf_download_error` |
+| 587 | Scripps Memorial Hospital Encinitas | unknown | — | `mrf_download_error` |
+| 592 | Scripps Memorial Hospital La Jolla | unknown | — | `mrf_download_error` |
+| 386 | Scripps Mercy Hospital Chula Vista | unknown | — | `mrf_download_error` |
+| 349 | Scripps Mercy Hospital San Diego | unknown | — | `mrf_download_error` |
+| 454 | Select Specialty Hospital - Fort Smith | unknown | — | `parse_error` |
+| 507 | Select Specialty Hospital - Youngstown | unknown | — | `parse_error` |
+| 62 | Seymour Hospital | unknown | — | `parse_error` |
+| 490 | Sheppard Pratt Health System | unknown | — | `parse_error` |
+| 77 | Shoshone Medical Center | unknown | — | `mrf_download_error` |
+| 159 | Silver Oaks Behavioral Hospital | unknown | — | `parse_error` |
+| 527 | Sioux Falls Specialty Hospital | unknown | — | `parse_error` |
+| 261 | Skagit Regional Health - Cascade Valley Hospital | unknown | — | `mrf_download_error` |
+| 114 | Skagit Regional Health - Skagit Valley Hospital | unknown | — | `mrf_download_error` |
+| 64 | Smokey Point Behavioral Hospital | unknown | — | `parse_error` |
+| 594 | Snoqualmie Valley Health | unknown | — | `mrf_download_error` |
+| 104 | Sojourn at Seneca | unknown | — | `mrf_download_error` |
+| 84 | South Coast Global Medical Center | unknown | — | `parse_error` |
+| 326 | South County Hospital | unknown | — | `mrf_download_error` |
+| 198 | South Lyon Medical Center | unknown | — | `parse_error` |
+| 608 | South Miami Hospital | unknown | — | `parse_error` |
+| 149 | South Mississippi Regional Medical Center | unknown | — | `parse_error` |
+| 38 | South Sound Behavioral Hospital | unknown | — | `parse_error` |
+| 478 | Southcoast Behavioral Health Hospital | unknown | — | `mrf_download_error` |
+| 301 | Southwell Medical Center | unknown | — | `parse_error` |
+| 448 | Springbrook Hospital | unknown | — | `parse_error` |
+| 277 | St Luke Hospital | unknown | — | `parse_error` |
+| 286 | St. Charles Bend | unknown | — | `parse_error` |
+| 267 | St. Charles Madras | unknown | — | `parse_error` |
+| 577 | St. Charles Prineville | unknown | — | `parse_error` |
+| 395 | St. Charles Redmond | unknown | — | `parse_error` |
+| 125 | St. Joseph Memorial Hospital | unknown | — | `mrf_download_error` |
+| 282 | St. Luke's Cornwall Hospital | unknown | — | `mrf_download_error` |
+| 540 | St. Luke's Cornwall Hospital - Cornwall Campus | unknown | — | `mrf_download_error` |
+| 442 | St. Luke's Cornwall Hospital - Cornwall Woundcare | unknown | — | `mrf_download_error` |
+| 61 | St. Luke's Cornwall Hospital - Hospital Extension Clinic | unknown | — | `mrf_download_error` |
+| 486 | St. Luke's Cornwall Hospital - Hospital PT | unknown | — | `mrf_download_error` |
+| 207 | St. Mary's Medical Center | unknown | — | `mrf_download_error` |
+| 548 | St. Raphael's Hospital | unknown | — | `parse_error` |
+| 500 | St. Vincent's Birmingham | unknown | — | `mrf_download_error` |
+| 453 | St. Vincent's Blount | unknown | — | `mrf_download_error` |
+| 212 | St. Vincent's Chilton, LLC | unknown | — | `mrf_download_error` |
+| 619 | St. Vincent's East | unknown | — | `mrf_download_error` |
+| 88 | St. Vincent's St. Clair, LLC | unknown | — | `mrf_download_error` |
+| 403 | Stamford Hospital | unknown | — | `parse_error` |
+| 569 | Stanislaus County Psychiatric Health Facility | unknown | — | `parse_error` |
+| 361 | Stephens Memorial Hospital | unknown | — | `parse_error` |
+| 316 | Story County Medical Center | unknown | — | `parse_error` |
+| 605 | Studer Family Children's Hospital Ascension Sacred Heart (Sacred Heart Health System, Inc.) | unknown | — | `mrf_download_error` |
+| 459 | Surgical Hospital at Southwoods | unknown | — | `parse_error` |
+| 268 | THE CHILDREN'S HOSPITAL AT TRISTAR CENTENNIAL | unknown | — | `mrf_download_error` |
+| 309 | THE NEW LONDON HOSPITAL ASSOCIATION, INC. | unknown | — | `mrf_download_error` |
+| 259 | TRISTAR CENTENNIAL PARTHEON PAVILION | unknown | — | `mrf_download_error` |
+| 291 | Taylor Regional Hospital | unknown | — | `mrf_download_error` |
+| 484 | Telecare El Dorado County Psychiatric Health Facility | unknown | — | `parse_error` |
+| 479 | Telecare Riverside Psychiatric Health Facility | unknown | — | `parse_error` |
+| 28 | Texas County Memorial Hospital | unknown | — | `parse_error` |
+| 195 | Texas Health Seay Behavioral Health Center Plano | unknown | — | `parse_error` |
+| 307 | The Unity Hospital of Rochester | unknown | — | `mrf_download_error` |
+| 304 | The Western Pennsylvania Hospital | unknown | — | `mrf_download_error` |
+| 167 | Tift Regional Medical Center | unknown | — | `parse_error` |
+| 99 | Totally Kids Rehabilitation  Hospital | unknown | — | `mrf_download_error` |
+| 367 | Touro | unknown | — | `parse_error` |
+| 310 | Tower Behavioral Health | unknown | — | `mrf_download_error` |
+| 131 | Tri-City Medical Center | unknown | — | `mrf_download_error` |
+| 375 | Tristar Spring Hill ER | unknown | — | `mrf_download_error` |
+| 45 | Troy Regional Medical Center | unknown | — | `parse_error` |
+| 196 | TrustPoint Hospital | unknown | — | `mrf_download_error` |
+| 87 | UCHealth Memorial Hospital Central | unknown | — | `mrf_download_error` |
+| 30 | UCHealth Memorial Hospital North | unknown | — | `mrf_download_error` |
+| 377 | UCHealth Parkview Medical Center | unknown | — | `mrf_download_error` |
+| 80 | UCHealth Parkview Pueblo West Hospital | unknown | — | `mrf_download_error` |
+| 570 | UCI Health - Lakewood | unknown | — | `mrf_download_error` |
+| 96 | UCSF Langley Porter Psychiatric Hospital | unknown | — | `parse_error` |
+| 597 | UChicago Medicine AdventHealth GlenOaks | unknown | — | `parse_error` |
+| 397 | UMass Memorial Health-Milford Regional Medical Center | unknown | — | `mrf_download_error` |
+| 101 | UPMC Kane | unknown | — | `mrf_download_error` |
+| 106 | UPMC Somerset | unknown | — | `mrf_download_error` |
+| 90 | Union Hospital | unknown | — | `mrf_download_error` |
+| 428 | Unity Medical Center | unknown | — | `parse_error` |
+| 359 | UnityPoint Health - Allen Hospital | unknown | — | `mrf_download_error` |
+| 599 | UnityPoint Health - Finley Hospital | unknown | — | `mrf_download_error` |
+| 446 | UnityPoint Health - Grinnell Regional Medical Center | unknown | — | `mrf_download_error` |
+| 469 | UnityPoint Health - Iowa Lutheran Hospital | unknown | — | `mrf_download_error` |
+| 364 | UnityPoint Health - Iowa Methodist Medical Center | unknown | — | `mrf_download_error` |
+| 203 | UnityPoint Health - Jones Regional Medical Center | unknown | — | `mrf_download_error` |
+| 206 | UnityPoint Health - Marshalltown | unknown | — | `mrf_download_error` |
+| 511 | UnityPoint Health - Meriter Hospital | unknown | — | `mrf_download_error` |
+| 481 | UnityPoint Health - St. Luke's Hospital | unknown | — | `mrf_download_error` |
+| 138 | UnityPoint Health - St. Luke's Regional Medical Center | unknown | — | `mrf_download_error` |
+| 528 | UnityPoint Health - Trinity Bettendorf | unknown | — | `mrf_download_error` |
+| 69 | UnityPoint Health - Trinity Muscatine | unknown | — | `mrf_download_error` |
+| 458 | UnityPoint Health - Trinity Regional Medical Center | unknown | — | `mrf_download_error` |
+| 56 | University Hospitals Avon Rehabilitation Hospital | unknown | — | `mrf_download_error` |
+| 232 | University Medical Center | unknown | — | `parse_error` |
+| 147 | University of Utah Hospital | unknown | — | `mrf_download_error` |
+| 199 | Valley Regional Hospital | unknown | — | `parse_error` |
+| 35 | Valley View Hospital | unknown | — | `mrf_download_error` |
+| 110 | Valleywise Health Medical Center | unknown | — | `mrf_download_error` |
+| 612 | Vanderbilt Bedford Hospital | unknown | — | `mrf_download_error` |
+| 589 | Vanderbilt Tullahoma-Harton Hospital | unknown | — | `mrf_download_error` |
+| 392 | Vanderbilt University Medical Center | unknown | — | `mrf_download_error` |
+| 404 | Vanderbilt Wilson County Hospital | unknown | — | `mrf_download_error` |
+| 76 | Vantage Point Behavioral Health Hospital | unknown | — | `mrf_download_error` |
+| 250 | Wabash General Hospital District | unknown | — | `parse_error` |
+| 197 | Wamego Health Center (Wamego Hospital Association) | unknown | — | `mrf_download_error` |
+| 243 | Washington County Hospital | unknown | — | `parse_error` |
+| 451 | Washington Regional Medical Center | unknown | — | `mrf_download_error` |
+| 40 | Webster County Memorial Hospital | unknown | — | `mrf_download_error` |
+| 557 | Weirton Medical Center | unknown | — | `parse_error` |
+| 542 | West Jefferson Medical Center | unknown | — | `parse_error` |
+| 251 | West Kendall Baptist Hospital | unknown | — | `parse_error` |
+| 252 | Westerly Hospital | unknown | — | `parse_error` |
+| 71 | Westfield Memorial Hospital | unknown | — | `mrf_download_error` |
+| 238 | WhidbeyHealth | unknown | — | `parse_error` |
+| 571 | Williamson Medical Center | unknown | — | `mrf_download_error` |
+| 98 | Wilson Health | unknown | — | `mrf_download_error` |
+| 230 | Windom Area Health | unknown | — | `parse_error` |
+| 68 | Wiregrass Medical Center | unknown | — | `mrf_download_error` |
+| 217 | Wyckoff Heights Medical Center | unknown | — | `parse_error` |
+| 598 | Yale New Haven Hospital | unknown | — | `parse_error` |
+| 431 | Zachary-AMG Specialty Hospital | unknown | — | `parse_error` |
+| 443 | allied services institute of rehabilitation | unknown | — | `parse_error` |
+| 271 | creekside behavioral health | unknown | — | `parse_error` |
+| 545 | john heinz institute of rehabilitation | unknown | — | `parse_error` |
+
+## 5. Null-Location Providers (invisible to search)
+
+**385 providers** exist in Supabase but have `lat = NULL` and `lng = NULL`.
+These are **invisible to all distance-based searches** because PostGIS `ST_DWithin()` requires a non-null
+geometry point.
+
+**Root cause:** `geocodeByZip()` in `import-trilliant.ts` only extracts zip codes from the
+`hospital_address` string. These hospitals had addresses without a parseable 5-digit zip.
+The `hospital_city` and `hospital_state` fields were populated but never used for geocoding.
+
+### Geocoding Improvement Opportunity
+
+These providers could be fixed using `hospital_city + hospital_state` via the Google Maps
+Geocoding API (`NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` is already configured). Approach:
+
+1. Query `providers WHERE lat IS NULL AND trilliant_hospital_id IS NOT NULL`
+2. Geocode each via `{city}, {state}` → Google Maps Geocoding API → lat/lng
+3. `UPDATE providers SET lat=?, lng=? WHERE id=?`
+
+This is a separate task — not part of the NJ/PA reimport.
+
+### Full Listing
+
+| Name | State | City | Address | Trilliant ID |
+|------|-------|------|---------|-------------|
+| Athens-Limestone Hospital | AL | — | 700 W MARKET ST, Athens,AL 356112457 | 1621 |
+| Washington County Hospital and Nursing Home | AL | — | 14600 St. Stephens Ave | 3124 |
+| Baxter Health Fulton County Hospital | AR | Salem | 679 N Main Street, Salem, AR, 725769998 | 5256 |
+| Mercy Hospital Jefferson | AR | — | 1390 US Highway 61 Festus MO 6302 | 699 |
+| Mercy Hospital South | AR | — | 10050 Kennerly Road Saint Louis MO 63128 | 1975 |
+| Stone County Medical Center | AR | — | N/A | 979 |
+| White River Medical Center | AR | — | N/A | 2246 |
+| Abrazo Surprise Hospital | AZ | Surprise | 16815 W Bell Rd, Surprise, AZ 85374 | 5860 |
+| Avenir Behavioral Center | AZ | — | 16561 N PARKVIEW PLACE, SURPRISE AZ 85374 | 5829 |
+| Banner Boswell Medical Center | AZ | Sun City | 10401 West Thunderbird Blvd, Sun City, AZ 85351 | 2775 |
+| Banner Ironwood Medical Center | AZ | San Tan Valley | 37000 North Gantzel Road, San Tan Valley, AZ 85140 | 3165 |
+| ClearSky Rehabilitation Hospital of Avondale | AZ | Avondale | 10903 West McDowell Road, Avondale, AZ 85392 | 5136 |
+| Honor Health Deer Valley Medical Center | AZ | — | 19829 N 27th AVE, PHOENIX AZ 85027-4001 | 3141 |
+| Honor Health Sonoran Crossing Medical Center | AZ | — | 33400 N 32ND AVE, PHOENIX AZ 85085-8876 | 4560 |
+| Western Regional Medical Center | AZ | Goodyear | 14200 West Celebrate Life Way, Goodyear, AZ 85338 | 5559 |
+| ADVENTIST HEALTH - CLEAR LAKE | CA | — | 15630 18th Ave Clearlake CA 95422 | 4903 |
+| Children's Hospital of Orange County | CA | — | 1201 W La Veta Ave | 5601 |
+| CHOC at Mission Hospital | CA | — | 27700 Medical Center Rd | 4100 |
+| Coast Plaza Hospital | CA | Norwalk | 13100 Studebaker Road, Norwalk, CA 90650 | 5844 |
+| Community Memorial Healthcare - Ojai | CA | — | 1306 Maricopa Highway | 2707 |
+| Del Amo Behavioral Health System | CA | TORRANCE | 23700  CAMINO DEL SOL, TORRANCE, CA 90505 | 4874 |
+| Doctors Hospital of Riverside | CA | — | 3865 Jackson Street | 4938 |
+| Eisenhower Medical Center | CA | Rancho Mirage | 39000 Bob Hope Dr, Rancho Mirage, CA 92270 | 5928 |
+| Encino Hospital Medical Center | CA | — | 16237 Ventura Boulevard Encino, CA  91436 | 4184 |
+| Fairmont Hospital | CA | San Leandro | 15400 Foothill Blvd, San Leandro, CA 94578 | 4882 |
+| Fremont Hospital | CA | FREMONT | 39001 SUNDALE DRIVE, FREMONT, CA 94538 | 1501 |
+| Fremont Medical Center | CA | FREMONT | 39400 PASEO PADRE PARKWAY, FREMONT, CA 94538 | 2977 |
+| Garfield Medical Center | CA | — | 525 N Garfield Ave | 5400 |
+| Gateways Hospital and Mental Health Center | CA | Los Angeles | — | 1686 |
+| Hayward sisters hospital dba st rose hospital | CA | — | 27200 Calaroga Ave Hayward Ca  94545 | 2694 |
+| Hoag Hospital Irvine | CA | Irvine | 16200 Sand Canyon Avenue, Irvine, CA 92618 | 1879 |
+| Kindred Hospital Baldwin Park | CA | Baldwin Park | 14148 Francisquito Avenue, Baldwin Park, CA 91706 | 1735 |
+| Kindred Hospital La Mirada | CA | La Mirada | 14900 E Imperial Hwy, La Mirada, CA 90638 | 5666 |
+| Kindred Hospital Paramount | CA | Paramount | 16453  Colorado Avenue, Paramount, CA 90723 | 3573 |
+| Kindred Hospital Rancho | CA | Rancho Cucamonga | 10841 White Oak Avenue, Rancho Cucamonga, CA 91730 | 4086 |
+| Loma Linda University Medical Center Murrieta | CA | Murrieta | 28062 Baxter Road, Murrieta, CA 92563 | 1874 |
+| Los Angeles Community Hospital at Norwalk | CA | Norwalk | 13222 Bloomfield Ave, Norwalk, CA, 90650 | 6034 |
+| Los Angeles Downtown Medical Center | CA | — | 1711 W TEMPLE STREET SUITE 8135 | 5618 |
+| MemorialCare Saddleback Medical Center | CA | Laguna Hills | 24451 Health Center Drive, Laguna Hills, CA 92653 | 3133 |
+| Monterey Park Hospital | CA | — | 900 S Atlantic Blvd | 1831 |
+| Moreno Valley Medical Center | CA | MORENO VALLEY | 27300 IRIS AVENUE, MORENO VALLEY, CA 92555 | 3997 |
+| Northridge Hospital Medical Center | CA | Northridge | 18300 Roscoe Blvd, Northridge, CA 91328 | 1949 |
+| Providence Mission Hospital - Laguna Beach | CA | Laguna Beach | 31872 Coast Hwy, Laguna Beach, CA 92651 | 4647 |
+| Providence Mission Hospital - Mission Viejo | CA | Mission Viejo | 27700 Medical Center Rd, Mission Viejo, CA 92691 | 1059 |
+| Rehabilitation Hospital of Southern California, LLC | CA | Rancho Mirage | 70077 Ramon Road, Rancho Mirage, CA 92270 | 2207 |
+| Riverside Medical Center | CA | RIVERSIDE | 10800 MAGNOLIA AVE, RIVERSIDE, CA 92505 | 2539 |
+| San Leandro Hospital | CA | San Leandro | 13855 E 14th Street, San Leandro, CA 94578 | 4305 |
+| Sherman Oaks Hospital | CA | — | 4929 Van Nuys Boulevard Sherman Oaks, CA91403 | 4558 |
+| St Mary Medical Center | CA | Apple Valley | 18300 Highway 18, Apple Valley, CA 92307 | 2406 |
+| UCI Health - Fountain Valley | CA | Fountain Valley | 11250 Warner Avenue, Fountain Valley, CA 92708 | 1815 |
+| Valley Presbyterian Hospital | CA | Van Nuys | 15107 Vanowen Street, Van Nuys, CA 91405 | 3393 |
+| Whittier Hospital Medical Center | CA | — | 9080 Colima Road | 1140 |
+| Baxter Health | CO | — | TBD | 5949 |
+| Fulton County Medical Center | CO | — | 214 Peach  Orchard Rd Mc Connellsburg PA | 1707 |
+| HCA HealthONE CENTENNIAL, A PART OF AURORA HOSPITAL | CO | ENGLEWOOD | 14200 EAST ARAPHOE ROAD, ENGLEWOOD, CO, 80112 | 5327 |
+| HCA HealthONE NORTHEAST ER, A PART OF MOUNTAIN RIDGE HOSPITAL | CO | THORNTON | 12793 HOLLY STREET, THORNTON, CO, 80241 | 5264 |
+| OrthoColorado Hospital at St. Anthony Campus | CO | Lakewood | 11650 W 2nd Pl, Lakewood, CO 80228 | 4877 |
+| Spanish Peaks Regional Health Center | CO | — | 23500 Us Highway 160 Walsenburg CO 81089 | 5532 |
+| St. Anthony Hospital | CO | Lakewood | 11600 W 2nd Pl, Lakewood, CO 80228 | 907 |
+| St. Anthony North Health Campus | CO | Westminster | 14300 Orchard Pkwy, Westminster, CO 80023 | 2871 |
+| St. Francis Hospital - Interquest | CO | Colorado Springs | 10860 New Allegiance Drive, Colorado Springs, CO 80921 | 1823 |
+| UCHealth Broomfield Hospital | CO | Broomfield | 11820 Destination Drive, Broomfield, CO 80021 | 4741 |
+| UCHealth University of Colorado Hospital | CO | Aurora | 12605 E. 16th Avenue, Aurora, CO 80045 | 5022 |
+| Warren Medical Group | CO | — | TBD | 4288 |
+| AdventHealth Dade City | FL | Dade City | 13100 Fort King Road, Dade City, FL  33525 | 5208 |
+| AdventHealth Heart of Florida | FL | Davenport | 40100 US Highway 27, Davenport, FL  33837 \| 17430 Bali Boulevard, Winter Garden, FL  34787 | 2827 |
+| Baptist North Medical Campus | FL | Jacksonville | 11250 Baptist Health Drive, Jacksonville, FL  32218 | 4450 |
+| HCA FL HAINES CITY ER | FL | HAINES CITY | 36810 US HWY 27 N, HAINES CITY, FL, 33844 | 2668 |
+| HCA FL HUNTERS CREEK ER | FL | ORLANDO | 12100 SOUTH JOHN YOUNG PKWY, ORLANDO, FL, 32837 | 1190 |
+| HCA FL MOUNT DORA FSED | FL | MOUNT DORA | 16831 US HIGHWAY 441, MOUNT DORA, FL, 32757 | 2554 |
+| HCA FL PALM LAKES ER | FL | HIALEAH | 18000 NW 57TH AVE, HIALEAH, FL, 33015 | 1241 |
+| HCA FL SUMMERFIELD ER | FL | SUMMERFIELD | 14193 S US HIGHWAY 441, SUMMERFIELD, FL, 34491 | 2472 |
+| HCA FL TOWN AND COUNTRY ER | FL | MIAMI | 11800 SHERRI LN, MIAMI, FL, 33183 | 3479 |
+| HCA FL WEST END ER | FL | NEWBERRY | 12311 W NEWBERRY RD, NEWBERRY, FL, 32669 | 1598 |
+| HCA FLORIDA AVENTURA HOSPITAL | FL | AVENTURA | 20900 BISCAYNE BLVD, AVENTURA, FL, 33180 | 3162 |
+| HCA FLORIDA BAYONET POINT HOSPITAL | FL | HUDSON | 14000 FIVAY ROAD, HUDSON, FL, 34667 | 3101 |
+| HCA FLORIDA PALMS WEST HOSPITAL | FL | LOXAHATCHEE | 13001 SOUTHERN BLVD, LOXAHATCHEE, FL, 33470 | 5880 |
+| Jay Hospital | FL | — | 14114 Alabama Street, Jay FL 32565 | 4539 |
+| Lakeside Medical Center | FL | Belle Glade | 39200 Hooker Hwy., Belle Glade, FL 33430 | 1133 |
+| NEMOURS CHILDREN'S HOSPITAL | FL | — | 6535 Nemours Parkway | 1849 |
+| Orlando Health - Health Central Hospital | FL | Ocoee | 10000 W Colonial Dr, Ocoee, FL 34761 | 4365 |
+| Orlando Health Emergency Room - Reunion Village | FL | Ocoee | 10000 W Colonial Dr, Ocoee, FL 34761 | 5548 |
+| Orlando Health Horizon West Hospital | FL | Winter Garden | 17000 Porter Rd., Winter Garden, FL 34787 | 5597 |
+| Windmoor Healthcare of Clearwater | FL | CLEARWATER | 11300 U.S. HIGHWAY 19 NORTH, CLEARWATER, FL 33764 | 3061 |
+| Emanuel Medical Center | GA | — | N/A | 3137 |
+| Jasper Memorial Hospital | GA | — | N/A | 4517 |
+| Landmark Hospital of Savannah | GA | — | 800 East 68th St. Savannah, GA 3 | 689 |
+| Tanner Medical Center/Carrollton | GA | — | 705 Dixie Highway | 3753 |
+| Wayne Memorial Hospital | GA | — | N/A | 6024 |
+| Kohala Hospital | HI | — | 54-383 Hospital Rd | 1114 |
+| Kona Community Hospital | HI | — | 79-1019 Haukapila St | 5688 |
+| Leahi Hospital | HI | — | 3675 Kilauea Avenue | 3228 |
+| Cascade Medical Center | ID | — | N/A | 2837 |
+| Advocate South Suburban Hospital | IL | Hazel Crest | 17800 South Kedzie Avenue, Hazel Crest, IL 60429 | 5016 |
+| Ascension St. Vincent Carmel (St. Vincent Carmel Hospital, Inc.) | IN | — | 13500 N Meridian St Carmel IN 46032 | 1604 |
+| Franciscan Health Orthopedic-Carmel | IN | — | 10777 ILLINOIS STREET CARMEL, IN 46032 | 6009 |
+| Parkview Ortho Hospital | IN | Fort Wayne | 11130 Parkview Circle Dr, Fort Wayne, IN 46845 | 3017 |
+| RCG Taft Street | IN | — | 8555 Taft St | 4705 |
+| UChicago Crown Point | IN | Crown Point | 10855 Virginia Street, Crown Point, IN 46307 | 851 |
+| Ascension Via Christi Hospital St. Teresa, Inc. | KS | — | 14800 St Teresa St Wichita KS 67235 | 680 |
+| Cottonwood Springs | KS | — | 13351 S Arapaho Dr Olathe KS 66062 | 4653 |
+| Cottonwood Springs Changes | KS | — | 13351 S Arapaho Dr Olathe KS 66062 | 5326 |
+| Goodland Regional Medical Center | KS | — | N/A | 1742 |
+| Greeley County Health Services, Inc. | KS | — | 506 3rd Street | 1835 |
+| OVERLAND PARK REGIONAL MEDICAL CENTER | KS | Overland Park | 10500 Quivira, Overland Park, KS, 66215 | 4398 |
+| Rawlins County Health Center | KS | — | N/A | 2588 |
+| The University of Kansas Health System Olathe Hospital/Olathe Medical Center | KS | — | 20333 W. 151st Street, Olathe, Kansas 66061 | 4666 |
+| Baptist Health Rehabilitation Hospital | KY | Louisville | 11800 Bluegrass Pkwy, Louisville, KY 40299-2303 | 1434 |
+| Norton Audubon Hospital | KY | Louisville | One Audubon Plaza Drive, Louisville, KY 70217-1318 | 2031 |
+| Abbeville General Hospital | LA | — | 118 North Hospital Drive | 5707 |
+| Baton Rouge General - Ascension | LA | — | 3600 FLORIDA BLVD, BATON ROUGE,LA 708063842 | 3045 |
+| Baton Rouge General - Bluebonnet | LA | — | 3600 FLORIDA BLVD, BATON ROUGE,LA 708063842 | 1345 |
+| Baton Rouge General - Mid City | LA | — | 3600 FLORIDA BLVD, BATON ROUGE,LA 708063842 | 5911 |
+| Baton Rouge IOP | LA | — | 10425 Plaza Americana, Baton Rouge, Louisiana 70816 | 4949 |
+| Hammond IOP | LA | — | 10425 Plaza Americana, Baton Rouge, Louisiana 70816 | 1646 |
+| New Orleans Hospital | LA | — | 14500 Hayne Blvd, Suite 200, New Orleans, Louisiana 70128 | 1535 |
+| Northshore Hospital | LA | — | 64026 Hwy 434, Suite 300, Lacombe, Louisiana 70445 | 5425 |
+| Oceans Behavioral Hospital of Baton Rouge | LA | — | 11135 Florida Boulevard; Baton Rouge, LA 70518 | 3713 |
+| Ochsner Medical Center - Baton Rouge | LA | Baton Rouge | 17000 Medical Center Dr, Baton Rouge, LA 70816\|10310 The Grove Boulevard, Baton Rouge, LA 70836 | 5759 |
+| PAM Specialty Hospital of Hammond | LA | Hammond | 42074 Veterans Ave., Hammond, LA 70403 | 3689 |
+| Boston Children's Lexington | MA | — | 482 Bedford Street Lexington, MA 02173 | 2077 |
+| MedStar St Mary's Hospital | MD | — | 25500 Point Lookout Rd. Leonardtown, MD 20650 | 4930 |
+| Meritus Medical Center, Inc. | MD | — | 11116 Medical Campus Road Hagerstown, MD 21742 | 1125 |
+| North Oaks Medical Center | MD | Drive. Hammond | 15790 Paul Vega, MD, Drive. Hammond, LA 70403 | 2617 |
+| Rehabilitation Hospital of Bowie | MD | Bowie | 17351 Melford Blvd, Bowie, MD 20715-4457 | 5569 |
+| UPMC Western Maryland | MD | Cumberland | 12500 Willowbrook Road Se, Cumberland, MD 21502 | 709 |
+| UPMC Western Maryland | MD | Cumberland | 12500 Willowbrook Road Se, Cumberland, MD 21502 | 2921 |
+| Corewell Health Farmington Hills | MI | Farmington Hills | 28050 Grand River Avenue, Farmington Hills, MI 48336 | 2293 |
+| Corewell Health Taylor | MI | Taylor | 10000 Telegraph Road, Taylor, MI 48180 | 2885 |
+| Harbor Beach Community Hospital | MI | — | 210_S_1st_Street_Harbor_Beach_MI_48441 | 3881 |
+| Henry Ford Kingswood Hospital | MI | Ferndale | 10300 Eight Mile Rd, Ferndale, MI 48220 | 866 |
+| Henry Ford Macomb Hospital | MI | Clinton Twp | 15855 19 Mile Rd, Clinton Twp, MI 48038 | 3995 |
+| Henry Ford Warren Hospital | MI | Warren | 11800 Twelve Mile Rd, Warren, MI 48093 | 4531 |
+| McKenzie Health System | MI | — | 120_N._Delaware_St_Sandusky_MI_48471 | 3173 |
+| Munson Healthcare Charlevoix | MI | Charlevoix | 14700 Lake Shore Drive, Charlevoix, MI 49720 | 3526 |
+| ProMedica Charles and Virginia Hickman Hospital | MI | — | 5640 N Adrian Hwy | 1012 |
+| ProMedica Coldwater Regional Hospital | MI | — | 274 E Chicago St | 5240 |
+| ProMedica Monroe Regional Hospital | MI | — | 718 N. Macomb St. | 3344 |
+| StoneCrest Behavioral Health Hospital | MI | — | 15000 Gratiot Avenue, Detroit, Michigan 48205 | 1693 |
+| Trinity Health Ann Arbor | MI | Ypsilanti | 5301 McAuley Dr, Ypsilanti, MI 48171 | 1640 |
+| Allina Health Faribault Medical Center | MN | — | 200 St Ave. | 5722 |
+| Buffalo Hospital | MN | — | 303 Caitlin St | 1850 |
+| Cambridge Medical Center | MN | — | 701 Dellwood St S | 2206 |
+| Hendricks Community Hospital Association | MN | Hendricks | 503 E Lincoln St, Hendricks , MN | 4541 |
+| Owatonna Hospital | MN | — | 2250 26th St NW, | 3572 |
+| River Falls Area Hospital | MN | — | 1617 E Division St | 1987 |
+| CENTERPOINT MEDICAL CENTER | MO | Independence | 19600 E 39TH ST , Independence, MO, 64057 | 1316 |
+| Christian Hospital | MO | St. Louis | ['11133 Dunn Road, St. Louis, MO 63136', '1225 Dunn Road, St. Louis, MO 63031'] | 3968 |
+| Mercy Hospital St Louis | MO | — | 12990 Manchester RD STE 1 Saint Louis MO 63131 | 1243 |
+| Northwest HealthCare | MO | St. Louis | ['11133 Dunn Road, St. Louis, MO 63136', '1225 Dunn Road, St. Louis, MO 63031'] | 3667 |
+| Salem Memorial Hospital | MO | P.O. Box 774;Salem | 35629 Highway 72, P.O. Box 774;Salem, MO 65560 | 2678 |
+| SSM Health Rehabilitation Hospital - Bridgeton | MO | Saint Louis | 12380 DePaul Drive, Saint Louis, MO 63044 | 750 |
+| Washington County Memorial Hospital | MO | — | 300 HEALTH WAY DR | 3103 |
+| Gulfport Behavioral | MS | GULFPORT | 11150 HIGHWAY 49 NORTH, GULFPORT, MS 39503 | 716 |
+| Oceans Behavioral Hospital Biloxi | MS | — | 180C Debuys Road; Biloxi, MS 39351 | 4054 |
+| Ochsner Laird Hospital | MS | Union | 25117 Highway 15, Union, MS 39365 | 3857 |
+| Ochsner Stennis Hospital | MS | DeKalb | 14365 Highway 16 West, DeKalb, MS 39328 | 4969 |
+| Singing River Gulfport | MS | — | 15200 Community Rd,Gulfport,MS,39503 | 4311 |
+| Atrium Health Ballantyne Emergency Department, a facility of Atrium Health Pineville | NC | Charlotte | 10628 Park Rd, Charlotte, NC 28210  | 3750 |
+| Atrium Health Pineville | NC | Charlotte | 10628 Park Rd, Charlotte, NC 28210  | 2701 |
+| Atrium Health Providence Emergency Department, a facility of Atrium Health Pineville | NC | Charlotte | 10628 Park Rd, Charlotte, NC 28210  | 5202 |
+| Atrium Health Steele Creek Emergency Department, a facility of Atrium Health Pineville | NC | Charlotte | 10628 Park Rd, Charlotte, NC 28210  | 4711 |
+| Novant Health Ballantyne Medical Center | NC | — | 10905_Providence_Rd_West_Charlotte_NC_28277 | 5876 |
+| Novant Health Brunswick Medical Center | NC | — | 240_Hospital_Drive_NE_Bolivia_NC_28422 | 4866 |
+| Novant Health Charlotte Orthopedic Hospital | NC | — | 1901_Randolph_Rd._Charlotte_NC_28207 | 3930 |
+| Novant Health Clemmons Medical Center | NC | — | 6915_Village_Medical_Circle_Clemmons_NC_27012 | 1982 |
+| Novant Health Forsyth Medical Center | NC | — | 3333_Silas_Creek_Pkwy_Winston_Salem_NC_27103 | 4729 |
+| Novant Health Huntersville Medical Center | NC | — | 10030_Gilead_Road_Huntersville_NC_28078 | 3776 |
+| Novant Health Kernersville Medical Center | NC | — | 1750_Kernersville_Medical_Parkway_Kernersville_NC_27284 | 2614 |
+| Novant Health Matthews Medical Center | NC | — | 1500_Matthews_Township_Pkwy_Matthews_NC_28105 | 4169 |
+| Novant Health Medical Park Hospital | NC | — | 1950_South_Hawthorne_Rd_Winston_Salem_NC27103 | 1749 |
+| Novant Health Mint Hill Medical Center | NC | — | 8201_Healthcare_Loop_Charlotte_NC_28215 | 2990 |
+| Novant Health New Hanover Regional Medical Center | NC | — | 2131_S_17th_St_Wilmington_NC_28401 | 3553 |
+| Novant Health Pender Medical Center | NC | — | 507_E_Fremont_St_Burgaw_NC_28425 | 3024 |
+| Novant Health Presbyterian Medical Center | NC | — | 200_Hawthorne_Lane_Charlotte_NC_28204 | 5915 |
+| Novant Health Rowan Medical Center | NC | — | 612_Mocksville_Avenue_Salisbury_NC_28144 | 5552 |
+| Novant Health Thomasville Medical Center | NC | — | 207_Old_Lexington_Rd._Thomasville_NC_27360 | 2180 |
+| Boys Town National Research Hospital | NE | Boys Town | 14000 Boys Town Hospital Road, Boys Town, NE 68010 | 4050 |
+| CHI Health Midlands | NE | Papillion | 11111 S 84th Street, Papillion, NE 68046 | 4471 |
+| Atlantic Rehabilitation Institute | NJ | — | 200 Madison Avenue Madison NJ 7940 | 3412 |
+| Virtua Marlton Hospital | NJ | — | 90_Brick_Road_Marlton_NJ_08053 | 4372 |
+| Virtua Mount Holly Hospital | NJ | — | 175_Madison_Avenue_Mount_Holly_NJ_08060 | 5558 |
+| Virtua Our Lady of Lourdes Hospital | NJ | — | 1600_Haddon_Avenue_Camden_NJ_08103 | 2238 |
+| Virtua Voorhees Hospital | NJ | — | 100_Bowman_Drive_Voorhees_NJ_08043 | 1771 |
+| Virtua Willingboro Hospital | NJ | — | 218A_Sunset_Road_Willingboro_NJ_08046 | 5712 |
+| Miners Colfax Medical Center | NM | — | 203 Hospital Dr | 4381 |
+| LAS VEGAS HEART ASSOCIATES | NV | LAS VEGAS | — | 5070 |
+| MOUNTAINVIEW CRITICAL CARE ASSOCIATES | NV | LAS VEGAS | — | 5462 |
+| MOUNTAINVIEW MEDICAL ASSOCIATES | NV | LAS VEGAS | — | 1818 |
+| NEUROSCIENCES INPATIENT SERVICES | NV | LAS VEGAS | — | 729 |
+| NEVADA CARDIOVASCULAR AND THORACIC INST | NV | LAS VEGAS | — | 804 |
+| NEVADA NEUROSCIENCES INSTITUTE | NV | LAS VEGAS | — | 4948 |
+| SARAH CANNON BMT CLINIC AT MVH | NV | LAS VEGAS | — | 2138 |
+| SLS - MOUNTAINVIEW HOSPITAL | NV | LAS VEGAS | — | 3855 |
+| SLS - SUNRISE HOSPITAL AND MC | NV | LAS VEGAS | — | 2545 |
+| SOUTHERN HILLS CRITICAL CARE ASSOCIATES | NV | LAS VEGAS | — | 913 |
+| SUNRISE BURN | NV | LAS VEGAS | — | 5479 |
+| Carthage Area Hospital | NY | Carthage | 1001 West Street, Carthage, NY, 136199703 | 1607 |
+| Claxton Hepburn Medical Center | NY | — | 214 King St Ogdensburg, NY  | 3433 |
+| NYU Langone Hospital - Suffolk | NY | Patchogue | 101 Hospital Road, Patchogue, NY 1177 | 1165 |
+| avon hospital | OH | Avon | 33300 Cleveland Clinic Blvd, Avon, OH 44011 | 5910 |
+| Bethesda North Hospital | OH | — | 10500 Montgomery Road Cincinnati OH 45242 | 3695 |
+| Brunswick Medical Center & Emergency Room | OH | Middleburg Heights | 18697 Bagley Rd, Middleburg Heights, OH  | 2595 |
+| Institute for Orthopaedic Surgery | OH | — | 801 Medical Drive, Suite B | 931 |
+| Margaret Mary Health | OH | — | 321 Mitchell Avenue | 1827 |
+| marymount hospital | OH | Garfield Heights | 12300 McCracken Road, Garfield Heights, OH 44125 | 4521 |
+| PAM Health Rehabilitation Hospital of Miamisburg | OH | Miamisburg | 2310 Cross Pointe Dr, Miamisburg, OH | 2239 |
+| PERRYSBURG HOSPITAL | OH | Perrysburg | 12623 Eckel Junction Rd., Perrysburg, OH 43551 | 5945 |
+| ProMedica Bay Park Hospital | OH | — | 2801 Bay Park Dr | 1623 |
+| ProMedica Defiance Regional Hospital | OH | — | 1200 Ralston Ave | 4723 |
+| ProMedica Fostoria Community Hospital | OH | — | 501 Van Buren St | 3845 |
+| ProMedica Memorial Hospital | OH | — | 715 S. Taft Ave. | 5388 |
+| Select Specialty Hospital - Cincinnati North | OH | Cincinnati | 10500 Montgomery Road, Cincinnati, OH 45242 | 3940 |
+| Select Specialty Hospital - Cleveland Fairhill | OH | Cleveland | 11900 Fairhill Road, Cleveland, OH 44120-1062 | 5296 |
+| south pointe hospital | OH | Warrensville Heights | 20000 Harvard Road, Warrensville Heights, OH 44122 | 2981 |
+| Southwest General Health Center | OH | Middleburg Heights | 18697 Bagley Rd, Middleburg Heights, OH  | 5678 |
+| UH Rainbow Babies & Children's Hospital | OH | — | 11100 Euclid Avenue, Cleveland OH  44106  | 3539 |
+| University Hospitals Cleveland Medical Center | OH | — | 11100 Euclid Avenue, Cleveland OH  44106  | 4247 |
+| University Hospitals Lake West Medical Center | OH | — | 36000 Euclid Avenue, Willoughby OH  44094 | 4781 |
+| University Hospitals St. John Medical Center | OH | — | 29000 Center Ridge Road, Westlake OH, 44145 | 2734 |
+| Windsor-Laurelwood Center | OH | WILLOUGHBY | 35900 EUCLID AVE., WILLOUGHBY, OH 44094 | 3261 |
+| Brookhaven Hospital LLC | OK | Tulsa | 201 S Garnett Rd, Tulsa, OK | 2387 |
+| INTEGRIS Health Lakeside Women's Hospital | OK | Oklahoma City | 11200 North Portland Avenue, Oklahoma City, OK 73120 | 1545 |
+| Cedar Hills Hospital | OR | PORTLAND | 10300 SW EASTRIDGE ST, PORTLAND, OR 97225 | 1352 |
+| Curry Family Medical | OR | Gold Beach | 94220 4th Street, Gold Beach, OR 97444\ | 3004 |
+| Curry General Hospital | OR | Gold Beach | 94220 4th Street, Gold Beach, OR 97444\ | 2616 |
+| Curry Medical Center | OR | Gold Beach | 94220 4th Street, Gold Beach, OR 97444\ | 3614 |
+| Legacy Meridian Park Medical Center | OR | Tualatin | 19300 Sw 65Th Avenue, Tualatin, OR 97062 | 5850 |
+| Legacy Mount Hood Medical Center | OR | Gresham | 24800 Se Stark Street, Gresham, OR 97030 | 934 |
+| Oregon Health and Science University | OR | — | 3181 S.W. SAM JACKSON PARK RD., PORTLAND,OR 972393098 | 4395 |
+| Sunnyside Medical Center | OR | — | 10180 SE SUNNYSIDE ROAD CLACKAMAS OR 97015 | 4119 |
+| Vibra Specialty Hospital of Portland | OR | Portland | 10300 NE Hancock St, Portland, OR 97220 | 1267 |
+| Haven Behavioral Hospital of Philadelphia | PA | — | 3300 Henry Avenue | 5390 |
+| Heritage Valley Beaver | PA | — | 1000 Dutch Ridge Road, BEAVER,PA 150099727 | 1255 |
+| Heritage Valley Kennedy | PA | — | 720 BLACKBURN RD, SEWICKLEY,PA 151431459 | 1580 |
+| Heritage Valley Sewickley | PA | — | 720 BLACKBURN RD, SEWICKLEY,PA 151431459 | 3524 |
+| Jefferson Methodist Hospital | PA | Philadelphia | 2301 S Broad Street , Philadelphia, PA 19418 | 1644 |
+| Jefferson Torresdale Hospital | PA | Philadelphia | 10800 Knights Road , Philadelphia, PA 19114 | 4510 |
+| UPMC Green | PA | — | 250 Bonor Avenue  Waynesburg, PA | 4663 |
+| UPMC Green | PA | — | 250 Bonor Avenue  Waynesburg, PA | 5814 |
+| UPMC Washington | PA | — | 155 Wilson Avenue  Washington, PA | 2922 |
+| UPMC Washington | PA | — | 155 Wilson Avenue  Washington, PA | 1740 |
+| Warren General Hospital | PA | — | 2 Crescent Park West Warren PA | 4177 |
+| Charleston-AMG Specialty Hospital | SC | — | 1200 Hospital Drive | 5751 |
+| Ascension Saint Thomas Three Rivers | TN | — | 451 Highway 13 S Waverly TN | 1875 |
+| Turkey Creek Medical Center | TN | Knoxville | 10820 Parkside Dr, Knoxville, TN 37934 | 4840 |
+| WTH Camden Hospital | TN | — | 175 Hospital Dr | 1019 |
+| WTH Dyersburg Hospital | TN | — | 400 E Tickle St | 5355 |
+| WTH Volunteer Hospital | TN | — | 161 Mt Pelia Rd | 4155 |
+| 23330 Emergency Center, LLC d/b/a/ Elite Hospital Kingwood | TX | Kingwood | 23330 US-59, Kingwood, TX 77339 | 3074 |
+| Ascension Seton Northwest (Ascension Seton) | TX | — | 11113 Research Blvd Austin TX 78759 | 3085 |
+| Baptist Neighborhood Hospital -Shavano Park | TX | San Antonio | 16088 San Pedro Avenue, Suite 101, San Antonio, TX 78232 | 5835 |
+| Baptist Neighborhood Hospital Overlook | TX | San Antonio | 16088 San Pedro Avenue, Suite 101, San Antonio, TX 78232 | 5482 |
+| Baptist Neighborhood Hospital Rigsby | TX | San Antonio | 16088 San Pedro Avenue, Suite 101, San Antonio, TX 78232 | 693 |
+| Baptist Neighborhood Hospital Schertz | TX | San Antonio | 16088 San Pedro Avenue, Suite 101, San Antonio, TX 78232 | 2250 |
+| Baptist Neighborhood Hospital Thousand Oaks | TX | San Antonio | 16088 San Pedro Avenue, Suite 101, San Antonio, TX 78232 | 4181 |
+| Baptist Neighborhood Hospital Westover Hills | TX | Schertz | 16977 I-35 North, Suite 100, Schertz, TX 78154 | 3220 |
+| Baylor Scott & White Emergency Hospital Aubrey | TX | Aubrey | 26791 US Highway 380 E, Aubrey, TX 76227 | 4547 |
+| Baylor Scott & White Emergency Hospital Burleson | TX | Burleson | 12500 South Freeway, Suite 100, Burleson, TX 76028 | 1006 |
+| Baylor Scott & White Emergency Hospital Colleyville | TX | Aubrey | 26791 US Highway 380 E, Aubrey, TX 76227 | 3654 |
+| Baylor Scott & White Emergency Hospital Grand Prairie | TX | Burleson | 12500 South Freeway, Suite 100, Burleson, TX 76028 | 2533 |
+| Baylor Scott & White Emergency Hospital Keller | TX | Aubrey | 26791 US Highway 380 E, Aubrey, TX 76227 | 3895 |
+| Baylor Scott & White Emergency Hospital Mansfield | TX | Burleson | 12500 South Freeway, Suite 100, Burleson, TX 76028 | 1669 |
+| Baylor Scott & White Emergency Hospital Murphy | TX | Aubrey | 26791 US Highway 380 E, Aubrey, TX 76227 | 5576 |
+| Baylor Scott & White Emergency Hospital Rockwall | TX | Aubrey | 26791 US Highway 380 E, Aubrey, TX 76227 | 646 |
+| BAYLOR SCOTT & WHITE MEDICAL CENTER - CENTENNIAL | TX | Frisco | 12505 Lebanon Road, Frisco, TX 75035 | 4249 |
+| BAYLOR SCOTT & WHITE MEDICAL CENTER - LAKEWAY | TX | Lakeway | 100 Medical Parkway, Lakeway, TX | 2948 |
+| BAYLOR SCOTT & WHITE MEDICAL CENTER - TEMPLE | TX | Temple | 2401 S 31st Street, Temple, TX 96508 | 4939 |
+| BAYLOR SCOTT & WHITE PAVILION - TEMPLE | TX | — | TX | 1402 |
+| CHRISTUS Santa Rosa Emergency Center - Alon | TX | San Antonio | 11503 NW Military Hwy, San Antonio, TX 78230 | 755 |
+| Comanche County Medical Center | TX | — | 10201 TX-16 Comanche TX 76442 | 5508 |
+| Covenant Health Emergency Center - Quaker Ave | TX | Lubbock | 10205 Quaker Ave, Lubbock, TX 79424 | 4980 |
+| Eagle Lake | TX | — | Austin Road | 4391 |
+| Encompass Health Rehabilitation Hospital of Katy | TX | Katy | 23331 Grand Reserve Drive, Katy, TX 77494-4850 | 3582 |
+| Encompass Health Rehabilitation Hospital of The Woodlands | TX | Shenandoah | 18550 IH 45 South, Shenandoah, TX 77384-4119 | 1303 |
+| ER 24/7 NORTHWEST | TX | CORPUS CHRISTI | 13725 NORTHWEST BOULEVARD, CORPUS CHRISTI, TX, 78410 | 4378 |
+| Faith Community Hospital | TX | — | N/A | 653 |
+| Hamilton General Hospital | TX | — | North Brown Street | 1848 |
+| HCA HOUSTON ER 24/7 WILLOWBROOK | TX | HOUSTON | 22475 TOMBALL PKWY, HOUSTON, TX, 77070 | 3348 |
+| HCA HOUSTON KINGWOOD | TX | KINGWOOD | 22999 US HWY 59 NORTH, KINGWOOD, TX, 77339 | 5272 |
+| HCA HOUSTON PEARLAND | TX | Pearland | 11100 Shadow Creek Pkwy, Pearland, TX, 77584 | 2875 |
+| Heart of Texas Healthcare System | TX | — | Brady, TX | 1183 |
+| Houston Methodist Clear Lake Hospital | TX | Nassau Bay | 18300 St John Drive, Nassau Bay, TX 77058 | 3442 |
+| Houston Methodist Cypress Hospital | TX | Cypress | 24500 Northwest FWY, Cypress, TX 77429 | 1585 |
+| Houston Methodist Emergency Care Center at Cinco Ranch | TX | Houston | 18500 Katy Freeway, Houston, TX 77094 | 4844 |
+| Houston Methodist Emergency Care Center in Deer Park | TX | Nassau Bay | 18300 St John Drive, Nassau Bay, TX 77058 | 4221 |
+| Houston Methodist Emergency Care Center in League City | TX | Nassau Bay | 18300 St John Drive, Nassau Bay, TX 77058 | 1564 |
+| Houston Methodist West Hospital | TX | Houston | 18500 Katy Freeway, Houston, TX 77094 | 2324 |
+| Kindred Hospital Houston Northwest | TX | Houston | 11297 Fallbrook, Houston, TX 77065 | 633 |
+| Legent North Houston Surgical Hospital | TX | Tomball | 24429 Tomball Parkway, Tomball, TX, 77375 | 2586 |
+| Limestone Medical Center | TX | — | N/A | 4687 |
+| MEDICAL CITY ER HASLET | TX | HASLET | 13172 HIGHWAY 287, HASLET, TX, 76052 | 5768 |
+| Memorial Hermann Cypress Hospital | TX | — | 27800 Northwest Freeway Cypress TX 77433 | 6015 |
+| Memorial Hermann Imaging Center (Cypress) | TX | — | 27800 Northwest Freeway Cypress TX 77433 | 4253 |
+| Memorial Hermann Katy Hospital | TX | — | 23900 KATY FREEWAY KATY TX 77494 \|22430 Grand Corner Dr Ste C1 100 Katy TX 77494 | 4678 |
+| Memorial Hermann Pearland Hospital | TX | — | 16100 SOUTH FREEWAY Pearland TX 77584 | 1224 |
+| Memorial Hermann Southeast Hospital | TX | — | 11800 ASTORIA BOULEVARD Houston TX 77089 \|2555 Gulf Fwy S Ste C1 100 League City TX 77573 | 898 |
+| Memorial Hermann Sugar Land Hospital | TX | — | 17500 WEST GRAND PARKWAY SOUTH Sugar Land TX 77479 \|8780 Highway 6 Ste B100 Missouri City TX 77459 | 4080 |
+| Memorial Hermann Surgical Hospital First Colony | TX | Sugar Land | 16906 Southwest Fwy, Sugar Land, TX 77479 | 6006 |
+| METHODIST ER HELOTES | TX | HELOTES | 12285 BANDERA RD, HELOTES, TX, 78023 | 1300 |
+| METHODIST ER NACOGDOCHES | TX | SAN ANTONIO | 13434 NACOGDOCHES RD, SAN ANTONIO, TX, 78217 | 5131 |
+| Mid Coast Medical Clinic - Wharton | TX | Wharton | 10358 Hwy 59 #A , Wharton, TX 77488 | 1358 |
+| NEW BRAUNFELS ER | TX | NEW BRAUNFELS | 1850 W TX STATE HIGHWAY 46, NEW BRAUNFELS, TX, 78312 | 1245 |
+| NORTH AUSTIN MEDICAL CENTER | TX | AUSTIN | 12221 N MO PAC EXPY, AUSTIN, TX, 78758 | 5616 |
+| PAM Health Rehabilitation Hospital Northeast San Antonio | TX | San Antonio | 11407 Wayland Way, San Antonio, TX 78233 | 2247 |
+| PAM Rehabilitation Hospital of Humble | TX | Humble | 18839 McKay Blvd., Humble, TX 77338 | 5220 |
+| Rice Medical Center | TX | — | Austin Road | 4669 |
+| South Texas Spine & Surgical Hospital | TX | — | 18600 N. Hardy Oak Blvd,San Antonio,TX,78258 | 5734 |
+| ST. DAVID'S EMERGENCY CENTER - BEE CAVE | TX | BEE CAVE | 12813 GALLERIA CIR, BEE CAVE, TX, 78738 | 4966 |
+| St. Luke's Health - Lakeside Hospital | TX | The Woodlands | 17400 St Lukes Way, The Woodlands, TX 77384 | 5716 |
+| St. Luke's Health - The Woodlands Hospital | TX | The Woodlands | 17200 St Lukes Way, The Woodlands, TX 77384 | 5512 |
+| Texas Health Hospital Frisco | TX | Frisco | 12400 Dallas Parkway, Frisco, TX 75033 | 3096 |
+| Texas Health Methodist Hospital Alliance | TX | Fort Worth | 10864 Texas Health Trail, Fort Worth, TX 76244 | 5673 |
+| The Hospitals of Providence Emergency Room Montwood | TX | Horizon City | 13600 Horizon Blvd, Suite 100, Horizon City, TX 79928 | 4428 |
+| The Hospitals of Providence Horizon City Campus | TX | Horizon City | 13600 Horizon Blvd, Suite 100, Horizon City, TX 79928 | 2132 |
+| The Hospitals of Providence Northeast Campus | TX | Horizon City | 13600 Horizon Blvd, Suite 100, Horizon City, TX 79928 | 5836 |
+| UMC Health & Wellness Hospital | TX | Lubbock | 11011 Slide Road, Lubbock, TX 79424 | 1407 |
+| Warm Springs Rehabilitation Center Lockhart | TX | — | 1710 S. Colorado Street, Suite 102 | 3784 |
+| Warm Springs Rehabilitation Hospital of San Antonio | TX | San Antonio | 5101 Medical Drive, San Antonio, TX 7822 | 4958 |
+| Warm Springs Rehabilitation Hospital of Westover Hills | TX | San Antonio | 10323 State Highway 151, San Antonio, TX 78251 | 5815 |
+| Allen County Regional Hospital | unknown | — | 3066 North. Kentucky Street | 2038 |
+| Auburn Community Hospital | unknown | — | [] | 3020 |
+| BEAR VALLEY COMMUNITY HOSPITAL | unknown | Big Bear Lake | 41870 Garstin Drive, PO Box 1649, Big Bear Lake, CA, 92315-1649 | 1731 |
+| Clay County Medical Corporation | unknown | — | [] | 5644 |
+| Cleveland Area Hospital | unknown | — | [] | 4764 |
+| Coquille Valley Hospital | unknown | — | [] | 5926 |
+| Delta County Memorial Hospital | unknown | — | [] | 1404 |
+| Easton Avenue | unknown | — | [] | 1698 |
+| Hedrick Medical Center | unknown | — | 2799 North Washington Street | 5621 |
+| John H. Stroger Jr. Hospital | unknown | — | [] | 5182 |
+| Kell West Regional Hospital | unknown | — | [] | 5863 |
+| Macon Community Hospital | unknown | — | [] | 4324 |
+| Marion Regional Medical Center, Inc. | unknown | — | [] | 3044 |
+| Medical Behavioral Hospital of Clear Lake, LLC | unknown | — | [] | 855 |
+| Moffitt Cancer Center | unknown | — | 12902  Magnolia Dr, Tampa, Florida, 33612 | 4688 |
+| Monroe Health Services, Inc. | unknown | — | [] | 4418 |
+| Neosho Memorial Regional Medical Center | unknown | — | [] | 3437 |
+| North Mississippi Medical Center, Inc. | unknown | — | [] | 5671 |
+| Norton Scott Hospital | unknown | — | Norton Scott Hospital | 3991 |
+| Norton West Louisville Hospital | unknown | — | Norton West Louisville Hospital | 3740 |
+| Parkland Health | unknown | — | [] | 4073 |
+| Pontotoc Health Services, Inc. | unknown | — | [] | 1901 |
+| Provident Hospital Cook County | unknown | — | [] | 3400 |
+| Rothman Orthopaedic Specialty Hospital | unknown | — | 3300 Tillman Dr | 1729 |
+| Rural Wellness Fairfax | unknown | — | 40 Hospital Rd | 2823 |
+| Saint Luke's East Hospital | unknown | — | 100 N.E. Saint Luke's Boulevard | 3094 |
+| Saint Luke's North Hospital | unknown | — | 5830 NW Barry Road | 1587 |
+| Saint Luke's South Hospital | unknown | — | 12300 Metcalf Avenue | 2964 |
+| Shore Health Services, Inc. | unknown | — | 20480 Market Street, Onancock, Virginia 23417 | 1154 |
+| Surgical Specialty Center of Baton Rouge | unknown | — | [] | 3682 |
+| The Hospital at Westlake Medical Center | unknown | — | [] | 1869 |
+| Tishomingo Health Services, Inc. | unknown | — | [] | 2070 |
+| UAB St. Vincent's Blount | unknown | — | [] | 5736 |
+| UAB St. Vincent's Chilton | unknown | — | [] | 1860 |
+| UAB St. Vincent's East | unknown | — | [] | 1399 |
+| UMMC Grenada Hospital | unknown | — | [] | 2612 |
+| UMMC Holmes County Hospital | unknown | — | [] | 4848 |
+| UMMC Jackson Hospital | unknown | — | [] | 2003 |
+| UMMC Madison Hospital | unknown | — | [] | 2613 |
+| VCU Medical Center | unknown | — | 1250 East Marshall Street, Richmond VA | 3819 |
+| Vista Medical Center | unknown | — | [] | 3098 |
+| Webster Health Services, Inc. | unknown | — | [] | 1993 |
+| Wright Memorial Hospital | unknown | — | 191 Iowa Boulevard | 1938 |
+| HERRIMAN EMERGENCY CENTER | UT | HERRIMAN | 13306 S FORT HERRIMAN PKWY, HERRIMAN, UT, 84096 | 5857 |
+| Intermountain Health Riverton Hospital | UT | Riverton | 3741 W 12600 S, Riverton, UT 84065 | 1706 |
+| LONE PEAK HOSPITAL | UT | Draper | 11925 S State St, Draper, UT, 84020 | 3818 |
+| Children's Hospital of The King's Daughters | VA | — | 601 Children's Lane | 5421 |
+| Johnston Memorial Hospital | VA | — | 16000 JOHNSTON MEMORIAL DRIVE, ABINGDON,VA 24211 | 2988 |
+| North Spring Behavioral Healthcare | VA | LEESBURG | 42009 VICTORY LANE, LEESBURG, VA 20176 | 1985 |
+| Sentara Lake Ridge | VA | Lake Ridge | 12825 Minnieville Road, Lake Ridge, VA 22192 | 3184 |
+| Sheltering Arms Institute | VA | — | [] | 5436 |
+| ST FRANCIS MEDICAL CENTER | VA | Midlothian | 13710 St. Francis Blvd., Midlothian, VA 23114 | 3738 |
+| MultiCare Covington Medical Center | WA | Covington | 17700 SE 272nd Street, Covington, WA 98042 | 968 |
+| MultiCare Valley Hospital | WA | Spokane Valley | 12606 East Mission Ave, Spokane Valley, WA 99216 | 2028 |
+| St. Anne Hospital | WA | Burien | 16251 Sylvester Rd SW, Burien, WA 98166 | 2863 |
+| St. Anthony Hospital | WA | Gig Harbor | 11567 Canterwood Blvd, Gig Harbor, WA 98332 | 4740 |
+| St. Clare Hospital | WA | Lakewood | 11315 Bridgeport Way SW, Lakewood, WA 98499 | 4601 |
+| St. Francis Hospital | WA | Federal Way | 34515 Ninth Avenue South, Federal Way, WA 98003 | 897 |
+| Swedish Medical Center - Redmond Campus | WA | Redmond | 18100 NE Union Hill Rd, Redmond, WA 98052 | 5893 |
+| Aurora Medical Center Kenosha | WI | Kenosha | 10400 75th St, Kenosha, WI 53027 | 4973 |
+| Aurora Medical Center Summit | WI | Summit | 36500 Aurora Dr, Summit, WI 53066 | 5093 |
+| Cumberland Healthcare | WI | Cumberland | 1705 16th Ave, Cumberland, WI 54829860 | 908 |
+| Froedtert Bluemound Rehabilitation Hospital | WI | Wauwatosa | 10000 W Bluemound Rd, Wauwatosa, WI 53226 | 3541 |
+| Summersville Regional Medical Center | WV | Summersville | 400 Fairview Heights Rd, Summersville, WV 26551 | 2046 |
+| Niobrara Community Hospital | WY | — | N/A | 2798 |
+
+## 6. Post-Import Verification Targets
+
+After the NJ/PA reimport, re-run this script and verify the following:
+
+| Metric | Expected After Reimport | Verify Via |
+|--------|------------------------|------------|
+| Total Supabase charges | 13,115,274 | Section 1 Funnel — gap = 0 |
+| NJ Supabase charges | See NJ row in Section 3 (DDB Charges column) | NJ row Match = ✓ |
+| PA Supabase charges | See PA row in Section 3 (DDB Charges column) | PA row Match = ✓ |
+| NJ providers | See NJ row — DDB Hosps column | NJ SB Providers = DDB Hosps |
+| PA providers | See PA row — DDB Hosps column | PA SB Providers = DDB Hosps |
+| Null-location providers | 385 (unchanged by reimport) | Section 5 count |
+
+_Null-location count will not change with NJ/PA reimport — those providers are already in Supabase._
+_Fixing null-location requires a separate geocoding task (see Section 5)._

--- a/lib/data/generate-snapshot.ts
+++ b/lib/data/generate-snapshot.ts
@@ -1,0 +1,462 @@
+/**
+ * generate-snapshot.ts — ClearCost Data Audit Snapshot Generator
+ *
+ * Queries both DuckDB (Trilliant Oria Parquet warehouse) and Supabase (production
+ * Postgres) to produce a comprehensive data funnel audit. Answers:
+ *   1. Which hospitals were never imported (status != 'completed')?
+ *   2. Which providers are invisible to search (null lat/lng)?
+ *   3. What is the exact per-state breakdown across both databases?
+ *
+ * Output: docs/data-snapshot.md
+ *
+ * Run with:
+ *   npx tsx --env-file=.env.local lib/data/generate-snapshot.ts
+ *
+ * Notes:
+ *   - The per-state filtered charge count query scans all Parquet files (~81GB).
+ *     Expect 3-5 minutes for that step.
+ *   - DuckDB requires CWD = lib/data/mrf_lake/ for relative parquet/ paths.
+ *   - Keep this script in the repo — re-run after each import to verify totals.
+ */
+
+import { Database } from "duckdb-async";
+import { Pool as PgPool } from "pg";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import { readFileSync, writeFileSync } from "fs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const DB_PATH = resolve(__dirname, "mrf_lake/mrf_lake.duckdb");
+const CODES_PATH = resolve(__dirname, "final-codes.json");
+// Resolve output path before chdir changes CWD
+const OUTPUT_PATH = resolve(__dirname, "../../docs/data-snapshot.md");
+
+// ---------------------------------------------------------------------------
+// Types — DuckDB returns BigInt for COUNT(*); Postgres returns string
+// ---------------------------------------------------------------------------
+
+interface HospitalStatusRow { status: string | null; cnt: bigint; }
+interface TotalChargesRow   { total: bigint; }
+interface StateStatusRow    { hospital_state: string | null; status: string | null; cnt: bigint; }
+interface StateChargeRow    { hospital_state: string | null; cnt: bigint; }
+interface ExcludedHospRow   {
+  hospital_id: bigint;
+  hospital_name: string | null;
+  hospital_state: string | null;
+  hospital_city: string | null;
+  hospital_address: string | null;
+  status: string | null;
+}
+
+interface PgProvStateRow  { state: string; total: string; geocoded: string; null_location: string; }
+interface PgChargeStateRow { state: string; cnt: string; }
+interface PgNullProvRow   {
+  name: string | null;
+  state: string | null;
+  city: string | null;
+  address: string | null;
+  trilliant_hospital_id: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fmtNum(n: number | bigint | string | null | undefined): string {
+  if (n == null) return "—";
+  return Number(n).toLocaleString();
+}
+
+function mdEscape(s: string | null | undefined): string {
+  return (s ?? "—").replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const dbUrl = process.env.SUPABASE_DB_URL;
+  if (!dbUrl) {
+    console.error(
+      "Missing SUPABASE_DB_URL.\n" +
+      "Run with: npx tsx --env-file=.env.local lib/data/generate-snapshot.ts"
+    );
+    process.exit(1);
+  }
+
+  const codes: string[] = JSON.parse(readFileSync(CODES_PATH, "utf8"));
+  console.log(`Loaded ${codes.length} codes from final-codes.json`);
+
+  // ---------------------------------------------------------------------------
+  // DuckDB — must chdir to the DB directory for relative parquet/ paths
+  // ---------------------------------------------------------------------------
+
+  const dbDir = dirname(DB_PATH);
+  process.chdir(dbDir);
+  console.log(`\nChanged CWD to ${dbDir} (required for DuckDB parquet relative paths)`);
+
+  console.log("Opening DuckDB (read-only)...");
+  const db = await Database.create(DB_PATH, { access_mode: "READ_ONLY" });
+  await db.run(`SET memory_limit = '4GB'`);
+  await db.run(`SET threads = 2`);
+  console.log("DuckDB ready (memory_limit=4GB, threads=2)");
+
+  // ---------------------------------------------------------------------------
+  // Postgres
+  // ---------------------------------------------------------------------------
+
+  // Use pooler (6543) — fine for reads, handles reconnection
+  const poolerUrl = dbUrl.replace(/:5432\//, ":6543/");
+  const pgPool = new PgPool({
+    connectionString: poolerUrl,
+    ssl: { rejectUnauthorized: false },
+    max: 2,
+    idleTimeoutMillis: 60_000,
+    connectionTimeoutMillis: 30_000,
+  });
+  await pgPool.query("SELECT 1");
+  console.log("Postgres pool connected");
+
+  // ---------------------------------------------------------------------------
+  // DuckDB queries
+  // ---------------------------------------------------------------------------
+
+  console.log("\n[1/5] Hospital status breakdown...");
+  const statusRows = (await db.all(
+    `SELECT status, COUNT(*) AS cnt FROM hospitals GROUP BY status ORDER BY cnt DESC`
+  )) as unknown as HospitalStatusRow[];
+
+  console.log("[2/5] Total raw charge count from hospitals metadata...");
+  let totalRawCharges = 0;
+  try {
+    const totalRows = (await db.all(
+      `SELECT COALESCE(SUM(total_charges_count), 0) AS total FROM hospitals`
+    )) as unknown as TotalChargesRow[];
+    totalRawCharges = Number(totalRows[0]?.total ?? 0);
+    console.log(`  total_charges_count sum: ${totalRawCharges.toLocaleString()}`);
+  } catch {
+    console.warn("  total_charges_count column not found — using known approximate (274,000,000)");
+    totalRawCharges = 274_000_000;
+  }
+
+  console.log("[3/5] Per-state hospital counts (all statuses)...");
+  const stateStatusRows = (await db.all(
+    `SELECT hospital_state, status, COUNT(*) AS cnt
+     FROM hospitals
+     GROUP BY hospital_state, status
+     ORDER BY hospital_state, status`
+  )) as unknown as StateStatusRow[];
+
+  console.log("[4/5] Per-state FILTERED charge counts (1,010 codes + outpatient + completed hospitals only)...");
+  console.log("  ⚠  Scanning ~81GB Parquet — this may take 3-5 minutes...");
+  const codeList = codes.map((c) => `'${c}'`).join(",");
+  const stateChargeRows = (await db.all(
+    `SELECT h.hospital_state, COUNT(*) AS cnt
+     FROM standard_charges sc
+     JOIN hospitals h ON sc.hospital_id = h.hospital_id
+     WHERE (sc.cpt IN (${codeList}) OR sc.hcpcs IN (${codeList}))
+       AND (sc.setting IS NULL OR LOWER(sc.setting) != 'inpatient')
+       AND h.status = 'completed'
+     GROUP BY h.hospital_state
+     ORDER BY h.hospital_state`
+  )) as unknown as StateChargeRow[];
+  console.log(`  Got charge counts for ${stateChargeRows.length} states`);
+
+  console.log("[5/5] Non-completed hospitals detail...");
+  const excludedRows = (await db.all(
+    `SELECT hospital_id, hospital_name, hospital_state, hospital_city,
+            hospital_address, status
+     FROM hospitals
+     WHERE status != 'completed'
+     ORDER BY hospital_state, hospital_name`
+  )) as unknown as ExcludedHospRow[];
+  console.log(`  Found ${excludedRows.length} non-completed hospitals`);
+
+  await db.close();
+  console.log("DuckDB closed");
+
+  // ---------------------------------------------------------------------------
+  // Supabase / Postgres queries
+  // ---------------------------------------------------------------------------
+
+  console.log("\n[A/3] Provider counts per state (with geocoding status)...");
+  const provStateRes = await pgPool.query<PgProvStateRow>(`
+    SELECT state,
+      COUNT(*)                                          AS total,
+      COUNT(*) FILTER (WHERE lat IS NOT NULL)           AS geocoded,
+      COUNT(*) FILTER (WHERE lat IS NULL)               AS null_location
+    FROM providers
+    WHERE trilliant_hospital_id IS NOT NULL
+    GROUP BY state
+    ORDER BY state
+  `);
+  const provByState = new Map(provStateRes.rows.map((r) => [r.state, r]));
+  console.log(`  Got provider data for ${provStateRes.rows.length} states`);
+
+  console.log("[B/3] Charge counts per state...");
+  const chargeStateRes = await pgPool.query<PgChargeStateRow>(`
+    SELECT p.state, COUNT(*) AS cnt
+    FROM charges c
+    JOIN providers p ON c.provider_id = p.id
+    GROUP BY p.state
+    ORDER BY p.state
+  `);
+  const chargesByState = new Map(chargeStateRes.rows.map((r) => [r.state, Number(r.cnt)]));
+  console.log(`  Got charge data for ${chargeStateRes.rows.length} states`);
+
+  console.log("[C/3] Null-location providers...");
+  const nullProvRes = await pgPool.query<PgNullProvRow>(`
+    SELECT name, state, city, address, trilliant_hospital_id
+    FROM providers
+    WHERE lat IS NULL AND trilliant_hospital_id IS NOT NULL
+    ORDER BY state, name
+  `);
+  console.log(`  Found ${nullProvRes.rows.length} null-location providers`);
+
+  await pgPool.end();
+  console.log("Postgres pool closed");
+
+  // ---------------------------------------------------------------------------
+  // Compute aggregate summaries
+  // ---------------------------------------------------------------------------
+
+  const totalHospitals    = statusRows.reduce((s, r) => s + Number(r.cnt), 0);
+  const completedHospitals = Number(statusRows.find((r) => r.status === "completed")?.cnt ?? 0);
+  const excludedCount     = totalHospitals - completedHospitals;
+
+  const totalDuckDbFilteredCharges = stateChargeRows.reduce((s, r) => s + Number(r.cnt), 0);
+
+  const totalSupabaseProviders = [...provByState.values()].reduce((s, r) => s + Number(r.total), 0);
+  const totalSupabaseGeocoded  = [...provByState.values()].reduce((s, r) => s + Number(r.geocoded), 0);
+  const totalSupabaseNullLoc   = [...provByState.values()].reduce((s, r) => s + Number(r.null_location), 0);
+  const totalSupabaseCharges   = [...chargesByState.values()].reduce((s, n) => s + n, 0);
+
+  // Build per-state DuckDB maps
+  const duckStateMap = new Map<string, { completed: number; total: number }>();
+  for (const row of stateStatusRows) {
+    const st = row.hospital_state ?? "UNKNOWN";
+    if (!duckStateMap.has(st)) duckStateMap.set(st, { completed: 0, total: 0 });
+    const entry = duckStateMap.get(st)!;
+    entry.total += Number(row.cnt);
+    if (row.status === "completed") entry.completed += Number(row.cnt);
+  }
+  const duckChargeMap = new Map(
+    stateChargeRows.map((r) => [r.hospital_state ?? "UNKNOWN", Number(r.cnt)])
+  );
+
+  // All states across both databases
+  const allStates = [...new Set([
+    ...duckStateMap.keys(),
+    ...provByState.keys(),
+    ...chargesByState.keys(),
+  ])].sort();
+
+  const gap = totalDuckDbFilteredCharges - totalSupabaseCharges;
+
+  // ---------------------------------------------------------------------------
+  // Build Markdown
+  // ---------------------------------------------------------------------------
+
+  console.log("\nGenerating markdown...");
+  const now = new Date().toISOString();
+  const lines: string[] = [];
+
+  // Header
+  lines.push(`# ClearCost Data Snapshot`);
+  lines.push(``);
+  lines.push(`_Generated: ${now}_`);
+  lines.push(``);
+  lines.push(`To regenerate after an import:`);
+  lines.push(`\`\`\`bash`);
+  lines.push(`cd /Users/chrispratt/clearcost`);
+  lines.push(`npx tsx --env-file=.env.local lib/data/generate-snapshot.ts`);
+  lines.push(`\`\`\``);
+  lines.push(``);
+
+  // ---------------------------------------------------
+  // 1. Data Funnel
+  // ---------------------------------------------------
+  lines.push(`## 1. Data Funnel`);
+  lines.push(``);
+  lines.push(`\`\`\``);
+  lines.push(`DuckDB (Trilliant Oria)`);
+  lines.push(`  ├─ Hospitals total:              ${totalHospitals.toLocaleString().padStart(12)}`);
+  lines.push(`  │    ├─ status=completed:        ${completedHospitals.toLocaleString().padStart(12)}  → imported to Supabase`);
+  lines.push(`  │    └─ other status (excluded): ${excludedCount.toLocaleString().padStart(12)}  → never queried (see Section 4)`);
+  lines.push(`  │`);
+  lines.push(`  ├─ Raw charges (sum of total_charges_count across all hospitals):`);
+  lines.push(`  │         ${totalRawCharges.toLocaleString().padStart(18)}  (~274M, not all are for our codes)`);
+  lines.push(`  │`);
+  lines.push(`  └─ Filtered charges (1,010 codes, outpatient only, completed hospitals):`);
+  lines.push(`             ${totalDuckDbFilteredCharges.toLocaleString().padStart(14)}`);
+  lines.push(``);
+  lines.push(`Supabase (current state)`);
+  lines.push(`  ├─ Providers: ${totalSupabaseProviders.toLocaleString().padStart(8)}  (${totalSupabaseGeocoded.toLocaleString()} geocoded, ${totalSupabaseNullLoc.toLocaleString()} null lat/lng — see Section 5)`);
+  lines.push(`  └─ Charges:   ${totalSupabaseCharges.toLocaleString().padStart(8)}`);
+  lines.push(``);
+  lines.push(`  Gap: ${gap.toLocaleString()} charges not yet in Supabase`);
+  if (gap > 0) {
+    lines.push(`       (Expected if NJ/PA not yet reimported. See MISSING rows in Section 3.)`);
+  }
+  lines.push(`\`\`\``);
+  lines.push(``);
+
+  // ---------------------------------------------------
+  // 2. Hospital Status Breakdown
+  // ---------------------------------------------------
+  lines.push(`## 2. DuckDB Hospital Status Breakdown`);
+  lines.push(``);
+  lines.push(`| Status | Count |`);
+  lines.push(`|--------|------:|`);
+  for (const row of statusRows) {
+    lines.push(`| \`${row.status ?? "NULL"}\` | ${fmtNum(row.cnt)} |`);
+  }
+  lines.push(`| **Total** | **${fmtNum(totalHospitals)}** |`);
+  lines.push(``);
+
+  // ---------------------------------------------------
+  // 3. Per-State Table
+  // ---------------------------------------------------
+  lines.push(`## 3. Per-State Data Table`);
+  lines.push(``);
+  lines.push(`_DuckDB: completed hospitals + filtered charge count (1,010 codes, outpatient, completed hospitals only)_`);
+  lines.push(`_Supabase: providers imported + geocoding status + charges imported_`);
+  lines.push(`_**MISSING** = DuckDB has completed hospitals with charges, but Supabase has 0 charges (needs import)_`);
+  lines.push(``);
+  lines.push(`| State | DDB Hosps | DDB Charges | SB Providers | SB Geocoded | SB Null Loc | SB Charges | Match |`);
+  lines.push(`|-------|----------:|------------:|-------------:|------------:|------------:|-----------:|-------|`);
+
+  for (const st of allStates) {
+    const duck = duckStateMap.get(st);
+    const duckCharges = duckChargeMap.get(st) ?? 0;
+    const supa = provByState.get(st);
+    const supaCharges = chargesByState.get(st) ?? 0;
+    const duckCompleted = duck?.completed ?? 0;
+    const supaTotal    = supa ? Number(supa.total) : 0;
+    const supaGeocoded = supa ? Number(supa.geocoded) : 0;
+    const supaNullLoc  = supa ? Number(supa.null_location) : 0;
+
+    let match = "✓";
+    if (duckCompleted > 0 && supaCharges === 0 && duckCharges > 0) {
+      match = "**MISSING**";
+    } else if (duckCharges > 0 && supaCharges > 0) {
+      const pctDiff = Math.abs(duckCharges - supaCharges) / duckCharges;
+      if (pctDiff > 0.05) match = "⚠ partial";
+    }
+
+    lines.push(`| ${st} | ${fmtNum(duckCompleted)} | ${fmtNum(duckCharges)} | ${fmtNum(supaTotal)} | ${fmtNum(supaGeocoded)} | ${fmtNum(supaNullLoc)} | ${fmtNum(supaCharges)} | ${match} |`);
+  }
+  lines.push(``);
+
+  // ---------------------------------------------------
+  // 4. Excluded Hospitals
+  // ---------------------------------------------------
+  lines.push(`## 4. Excluded Hospitals (status != 'completed')`);
+  lines.push(``);
+  lines.push(`**${excludedRows.length.toLocaleString()} hospitals** were excluded from the import because Trilliant did not fully`);
+  lines.push(`process them — the \`status != 'completed'\` filter in \`importProviders()\` drops them before any charge`);
+  lines.push(`data is queried. These are a Trilliant data quality limitation, not a ClearCost bug.`);
+  lines.push(``);
+
+  // Group by status for summary
+  const byStatus = new Map<string, ExcludedHospRow[]>();
+  for (const row of excludedRows) {
+    const key = row.status ?? "NULL";
+    if (!byStatus.has(key)) byStatus.set(key, []);
+    byStatus.get(key)!.push(row);
+  }
+
+  lines.push(`### By Status`);
+  lines.push(``);
+  lines.push(`| Status | Count |`);
+  lines.push(`|--------|------:|`);
+  for (const [st, rows] of [...byStatus.entries()].sort((a, b) => b[1].length - a[1].length)) {
+    lines.push(`| \`${st}\` | ${rows.length.toLocaleString()} |`);
+  }
+  lines.push(``);
+
+  lines.push(`### Full Listing`);
+  lines.push(``);
+  lines.push(`| ID | Name | State | City | Status |`);
+  lines.push(`|----|------|-------|------|--------|`);
+  for (const row of excludedRows) {
+    lines.push(`| ${Number(row.hospital_id)} | ${mdEscape(row.hospital_name)} | ${row.hospital_state ?? "—"} | ${mdEscape(row.hospital_city)} | \`${row.status ?? "NULL"}\` |`);
+  }
+  lines.push(``);
+
+  // ---------------------------------------------------
+  // 5. Null-Location Providers
+  // ---------------------------------------------------
+  lines.push(`## 5. Null-Location Providers (invisible to search)`);
+  lines.push(``);
+  lines.push(`**${nullProvRes.rows.length.toLocaleString()} providers** exist in Supabase but have \`lat = NULL\` and \`lng = NULL\`.`);
+  lines.push(`These are **invisible to all distance-based searches** because PostGIS \`ST_DWithin()\` requires a non-null`);
+  lines.push(`geometry point.`);
+  lines.push(``);
+  lines.push(`**Root cause:** \`geocodeByZip()\` in \`import-trilliant.ts\` only extracts zip codes from the`);
+  lines.push(`\`hospital_address\` string. These hospitals had addresses without a parseable 5-digit zip.`);
+  lines.push(`The \`hospital_city\` and \`hospital_state\` fields were populated but never used for geocoding.`);
+  lines.push(``);
+  lines.push(`### Geocoding Improvement Opportunity`);
+  lines.push(``);
+  lines.push(`These providers could be fixed using \`hospital_city + hospital_state\` via the Google Maps`);
+  lines.push(`Geocoding API (\`NEXT_PUBLIC_GOOGLE_MAPS_API_KEY\` is already configured). Approach:`);
+  lines.push(``);
+  lines.push(`1. Query \`providers WHERE lat IS NULL AND trilliant_hospital_id IS NOT NULL\``);
+  lines.push(`2. Geocode each via \`{city}, {state}\` → Google Maps Geocoding API → lat/lng`);
+  lines.push(`3. \`UPDATE providers SET lat=?, lng=? WHERE id=?\``);
+  lines.push(``);
+  lines.push(`This is a separate task — not part of the NJ/PA reimport.`);
+  lines.push(``);
+  lines.push(`### Full Listing`);
+  lines.push(``);
+  lines.push(`| Name | State | City | Address | Trilliant ID |`);
+  lines.push(`|------|-------|------|---------|-------------|`);
+  for (const row of nullProvRes.rows) {
+    lines.push(`| ${mdEscape(row.name)} | ${row.state ?? "—"} | ${mdEscape(row.city)} | ${mdEscape(row.address)} | ${row.trilliant_hospital_id ?? "—"} |`);
+  }
+  lines.push(``);
+
+  // ---------------------------------------------------
+  // 6. Post-Import Verification Targets
+  // ---------------------------------------------------
+  lines.push(`## 6. Post-Import Verification Targets`);
+  lines.push(``);
+  lines.push(`After the NJ/PA reimport, re-run this script and verify the following:`);
+  lines.push(``);
+  lines.push(`| Metric | Expected After Reimport | Verify Via |`);
+  lines.push(`|--------|------------------------|------------|`);
+  lines.push(`| Total Supabase charges | ${fmtNum(totalDuckDbFilteredCharges)} | Section 1 Funnel — gap = 0 |`);
+  lines.push(`| NJ Supabase charges | See NJ row in Section 3 (DDB Charges column) | NJ row Match = ✓ |`);
+  lines.push(`| PA Supabase charges | See PA row in Section 3 (DDB Charges column) | PA row Match = ✓ |`);
+  lines.push(`| NJ providers | See NJ row — DDB Hosps column | NJ SB Providers = DDB Hosps |`);
+  lines.push(`| PA providers | See PA row — DDB Hosps column | PA SB Providers = DDB Hosps |`);
+  lines.push(`| Null-location providers | ${fmtNum(totalSupabaseNullLoc)} (unchanged by reimport) | Section 5 count |`);
+  lines.push(``);
+  lines.push(`_Null-location count will not change with NJ/PA reimport — those providers are already in Supabase._`);
+  lines.push(`_Fixing null-location requires a separate geocoding task (see Section 5)._`);
+
+  // ---------------------------------------------------------------------------
+  // Write output
+  // ---------------------------------------------------------------------------
+
+  const output = lines.join("\n");
+  writeFileSync(OUTPUT_PATH, output, "utf8");
+
+  console.log(`\nWrote ${(output.length / 1024).toFixed(1)} KB to ${OUTPUT_PATH}`);
+  console.log("\n=== Summary ===");
+  console.log(`  DuckDB hospitals:       ${totalHospitals.toLocaleString()} (${completedHospitals.toLocaleString()} completed, ${excludedCount.toLocaleString()} excluded)`);
+  console.log(`  DuckDB filtered charges: ${totalDuckDbFilteredCharges.toLocaleString()}`);
+  console.log(`  Supabase providers:     ${totalSupabaseProviders.toLocaleString()} (${totalSupabaseNullLoc.toLocaleString()} null lat/lng)`);
+  console.log(`  Supabase charges:       ${totalSupabaseCharges.toLocaleString()}`);
+  console.log(`  Gap:                    ${gap.toLocaleString()} charges missing`);
+  console.log("\nDone!");
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/lib/data/import-trilliant.ts
+++ b/lib/data/import-trilliant.ts
@@ -791,7 +791,7 @@ async function main() {
   console.log("  DuckDB memory_limit=2GB, threads=2");
 
   // Load the curated code list (1,010 codes from CMS 70 + CMS 200 + top 500 + FAIR Health)
-  const codesPath = resolve(dbDir, "final-codes.json");
+  const codesPath = resolve(__dirname, "final-codes.json");
   const importCodes: string[] = JSON.parse(readFileSync(codesPath, "utf8"));
   console.log(`  Loaded ${importCodes.length} codes from final-codes.json`);
 


### PR DESCRIPTION
Closes #3

## Summary

- Adds `lib/data/generate-snapshot.ts` — a permanent script that queries both DuckDB (Trilliant Oria Parquet) and Supabase to produce a full data funnel audit
- Generates `docs/data-snapshot.md` with the current state of the dataset
- Fixes a path bug in `import-trilliant.ts`: `codesPath` used `resolve(dbDir, ...)` which breaks when DuckDB lives in a subdirectory

## Key findings (satisfies issue #3 acceptance criteria)

- **DuckDB schema compatible** — all expected columns present, script ran cleanly
- **NJ expected charge count: 182,010** (1,010 curated codes, outpatient, completed hospitals)
- **PA expected charge count: 359,096**
- **Total filtered charges: 13,115,274** across all states
- Gap = 541,106 = NJ + PA exactly — confirms reimport scope

## Bonus findings documented

- 620 excluded hospitals (351 mrf_download_error + 269 parse_error) — Section 4
- 385 null-location providers with city+state listed — Section 5 (feeds #7)
- `total_charges_count` sums to 6.38B (payer-specific rows, not standard_charges rows)

## How to re-run after NJ/PA reimport
```bash
npx tsx --env-file=.env.local lib/data/generate-snapshot.ts
```
Expect 3-5 min for the Parquet scan. Verify Section 3 shows NJ and PA with Match = ✓ and gap = 0.

## Test plan
- [x] Script runs without error, exits 0
- [x] `docs/data-snapshot.md` written (90.8 KB)
- [x] Per-state DuckDB charges sum = 13,115,274
- [x] NJ and PA rows show `**MISSING**` in Section 3
- [x] 620 excluded hospitals listed in Section 4
- [x] 385 null-location providers listed in Section 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)