### PR TITLE
fix(import): handle null bytes and nested db-path layout

### DIFF
--- a/lib/data/import-trilliant.ts
+++ b/lib/data/import-trilliant.ts
@@ -666,13 +666,17 @@ async function flushOneBatch(
   numCols: number
 ): Promise<number> {
   // Build the SQL and values array
+  // Strip null bytes (0x00) from text fields — Postgres UTF8 rejects them
+  const sanitize = (v: unknown) =>
+    typeof v === "string" ? v.replace(/\x00/g, "") : v;
+
   const values: unknown[] = [];
   const rowPlaceholders: string[] = [];
   for (let r = 0; r < rows.length; r++) {
     const row = rows[r];
     const placeholders: string[] = [];
     for (let c = 0; c < numCols; c++) {
-      values.push(row[CHARGE_COLUMNS[c]] ?? null);
+      values.push(sanitize(row[CHARGE_COLUMNS[c]]) ?? null);
       placeholders.push(`$${r * numCols + c + 1}`);
     }
     rowPlaceholders.push(`(${placeholders.join(",")})`);
@@ -791,7 +795,7 @@ async function main() {
   console.log("  DuckDB memory_limit=2GB, threads=2");
 
   // Load the curated code list (1,010 codes from CMS 70 + CMS 200 + top 500 + FAIR Health)
-  const codesPath = resolve(dbDir, "final-codes.json");
+  const codesPath = resolve(__dirname, "final-codes.json");
   const importCodes: string[] = JSON.parse(readFileSync(codesPath, "utf8"));
   console.log(`  Loaded ${importCodes.length} codes from final-codes.json`);
 


### PR DESCRIPTION
## Summary

- **`__dirname` vs `dbDir` path fix**: `final-codes.json` was resolved relative to the DuckDB file's directory. When the re-downloaded data placed `mrf_lake.duckdb` inside `lib/data/mrf_lake/`, the two diverged. Now uses `__dirname` (the script's directory, always `lib/data/`) which is invariant.
- **Null byte sanitization**: Postgres UTF8 rejects `\x00` in text fields. Entire 500-row batches were failing silently with 3×retry waste (45s per bad batch). Added a `sanitize()` helper in `flushOneBatch()` that strips null bytes from string values before binding INSERT parameters.

## Result

NJ import: **182,010 charges, 0 failures, 0.0% difference vs DuckDB expected count**

## Test plan

- [x] `final-codes.json` resolves correctly when DuckDB is in a subdirectory
- [x] All 182,010 NJ charges imported with 0 batch failures
- [x] Top NJ providers have 5,272–7,905 charges each (well above 100)
- [x] Orphan charges: 0
- [x] Supabase count exactly matches DuckDB count (0.0% drift)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)