### PR TITLE
Replace results spinner with skeleton cards

### DIFF
--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -21,7 +21,6 @@ function ResultsContent() {
     interpretation,
     pricingPlan,
     loading,
-    loadingStage,
     error,
     view,
     setView,
@@ -196,7 +195,6 @@ function ResultsContent() {
             <ResultsList
               results={filteredResults}
               loading={loading}
-              loadingStage={loadingStage}
               selectedResultId={selectedResultId}
               codeDescriptionMap={codeDescriptionMap}
             />

--- a/components/ResultsList.tsx
+++ b/components/ResultsList.tsx
@@ -6,28 +6,15 @@ import { ResultCard } from "./ResultCard";
 interface ResultsListProps {
   results: ChargeResult[];
   loading?: boolean;
-  loadingStage?: string;
   selectedResultId?: string | null;
   codeDescriptionMap?: Record<string, string>;
 }
 
-export function ResultsList({ results, loading, loadingStage, selectedResultId, codeDescriptionMap }: ResultsListProps) {
+export function ResultsList({ results, loading, selectedResultId, codeDescriptionMap }: ResultsListProps) {
   if (loading) {
     return (
-      <div className="space-y-4">
-        {loadingStage && (
-          <div
-            className="flex items-center gap-2.5 text-sm font-medium animate-pulse-subtle"
-            style={{ color: "var(--cc-primary)" }}
-          >
-            <svg className="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none">
-              <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" opacity="0.25" />
-              <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-            </svg>
-            {loadingStage}
-          </div>
-        )}
-        {[1, 2, 3].map((i) => (
+      <div className="space-y-3">
+        {[1, 2, 3, 4, 5, 6].map((i) => (
           <div
             key={i}
             className="rounded-xl border overflow-hidden"
@@ -38,19 +25,35 @@ export function ResultsList({ results, loading, loadingStage, selectedResultId, 
           >
             <div className="flex">
               <div className="w-1 shrink-0 shimmer" />
-              <div className="flex-1 p-4 space-y-3">
-                <div className="flex items-center gap-2">
-                  <div className="w-6 h-6 rounded-lg shimmer" />
-                  <div className="h-4 w-48 shimmer" />
+              <div className="flex-1 p-4">
+                {/* Header: rank + name on left, price on right */}
+                <div className="flex justify-between items-start gap-4">
+                  <div className="flex-1 min-w-0 space-y-2">
+                    <div className="flex items-center gap-2">
+                      <div className="w-6 h-6 rounded-lg shimmer shrink-0" />
+                      <div className="h-4 w-48 shimmer" />
+                    </div>
+                    <div className="h-3 w-64 shimmer" />
+                    <div className="flex items-center gap-2">
+                      <div className="h-4 w-12 shimmer" />
+                      <div className="h-3 w-40 shimmer" />
+                    </div>
+                  </div>
+                  <div className="shrink-0 flex flex-col items-end gap-1">
+                    <div className="h-7 w-20 shimmer" />
+                    <div className="h-3 w-14 shimmer" />
+                  </div>
                 </div>
-                <div className="h-3 w-72 shimmer" />
-                <div className="h-3 w-32 shimmer" />
+                {/* Footer */}
                 <div
-                  className="pt-3 flex justify-between"
+                  className="mt-3 pt-3 flex items-center justify-between"
                   style={{ borderTop: "1px solid var(--cc-border)" }}
                 >
                   <div className="h-3 w-36 shimmer" />
-                  <div className="h-3 w-16 shimmer" />
+                  <div className="flex items-center gap-3">
+                    <div className="h-3 w-12 shimmer" />
+                    <div className="h-3 w-24 shimmer" />
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Replaced the standalone spinner + loading stage text with 6 shimmer skeleton cards in the results loading state
- Skeleton layout now mirrors `ResultCard` structure: rank + name left, price right, code badge, footer metadata
- Removed unused `loadingStage` prop from `ResultsList` interface and `page.tsx` call site
- Guided search assessment spinner untouched (different UX context)

Closes #13

## Review Notes
- `loadingStage` state still exists in `useResultsSearch.ts` hook (still called internally during fetches) — intentionally left; orphaned return value is harmless
- Code review passed with no high-confidence issues

## Test plan
- [ ] `npm run dev` → search for any procedure → confirm 6 shimmer skeleton cards appear during loading, no spinner
- [ ] Confirm skeleton card shapes visually match `ResultCard` proportions
- [ ] Navigate via guided search → confirm spinner still appears during AI assessment phase

🤖 Generated with [Claude Code](https://claude.ai/code)