### PR TITLE
Add billing class contextual callouts to result cards

### DIFF
--- a/components/ResultCard.tsx
+++ b/components/ResultCard.tsx
@@ -40,6 +40,13 @@ export function ResultCard({ result, rank, isSelected, codeDescriptionMap }: Res
     .filter(Boolean)
     .join(", ");
 
+  const billingClassCallout = (() => {
+    const bc = result.billingClass?.toLowerCase();
+    if (bc === "facility") return "Facility fee only — professional fees may apply separately";
+    if (bc === "professional") return "Professional fee only — facility charges may apply separately";
+    return null;
+  })();
+
   return (
     <div
       data-result-id={result.id}
@@ -185,6 +192,31 @@ export function ResultCard({ result, rank, isSelected, codeDescriptionMap }: Res
               )}
             </div>
           </div>
+
+          {/* Billing class callout */}
+          {billingClassCallout && (
+            <div
+              className="flex items-start gap-1.5 mt-2"
+              style={{ color: "var(--cc-accent)" }}
+            >
+              <svg
+                className="w-3.5 h-3.5 shrink-0 mt-0.5"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <circle cx="12" cy="12" r="10" />
+                <path d="M12 16v-4" />
+                <path d="M12 8h.01" />
+              </svg>
+              <span className="text-xs">
+                {billingClassCallout}
+              </span>
+            </div>
+          )}
 
           {/* Footer row */}
           <div


### PR DESCRIPTION
## Summary
- Surfaces `billingClass` data as amber info callouts on ResultCards when a price covers only facility or professional fees (not the full cost)
- `billing_class === "facility"` → "Facility fee only — professional fees may apply separately"
- `billing_class === "professional"` → "Professional fee only — facility charges may apply separately"
- `"Both"` or `null` → no callout

Closes #14

## Review Notes
- Code review passed with no high-confidence issues (all scored below 80/100 threshold)
- One deferred suggestion: adding `aria-hidden="true"` to the decorative SVG icon (scored 75 — pre-existing pattern across all ResultCard SVGs, not specific to this change)

## Test plan
- [ ] Search for a procedure with facility-only charges (e.g., MRI) — confirm amber callout appears
- [ ] Verify cards with `billingClass` of "both" or null show no callout
- [ ] Check mobile viewport (~375px) — text wraps cleanly, icon pins to first line
- [ ] Confirm amber color doesn't compete visually with teal price

🤖 Generated with [Claude Code](https://claude.ai/code)