### PR TITLE
Add distance radius filter to search results

### DIFF
--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -15,6 +15,16 @@ import {
 import { handleApiError } from "@/lib/api-helpers";
 import type { BillingCodeType, CPTCode, PricingPlan } from "@/types";
 
+const SPARSE_RESULT_THRESHOLD = 3;
+const EXPANDED_RADIUS_MILES = 250;
+
+async function lookupWithAutoExpand(params: Parameters<typeof lookupWithPricingPlan>[0]) {
+  const results = await lookupWithPricingPlan(params);
+  if (results.length >= SPARSE_RESULT_THRESHOLD) return results;
+  if ((params.radiusMiles ?? 100) >= EXPANDED_RADIUS_MILES) return results;
+  return lookupWithPricingPlan({ ...params, radiusMiles: EXPANDED_RADIUS_MILES });
+}
+
 type CacheStatus = "hit" | "miss" | "skip";
 
 function normalizeCodeType(value: unknown): BillingCodeType {
@@ -156,7 +166,7 @@ export async function POST(request: NextRequest) {
       return respond({ error: "Location is required" }, 400);
     }
 
-    const radiusMiles = location.radiusMiles || 25;
+    const radiusMiles = location.radiusMiles || 100;
     const { lat, lng } = location;
     const directCodeGroups = normalizeCodeGroups(directCodeGroupsRaw);
     const normalizedDirectCodes = Array.isArray(directCodes)
@@ -185,7 +195,7 @@ export async function POST(request: NextRequest) {
       });
       const lookupDiagnostics = createLookupDiagnostics();
 
-      const results = await lookupWithPricingPlan({
+      const results = await lookupWithAutoExpand({
         pricingPlan,
         lat,
         lng,
@@ -231,7 +241,7 @@ export async function POST(request: NextRequest) {
       });
       const lookupDiagnostics = createLookupDiagnostics();
 
-      const results = await lookupWithPricingPlan({
+      const results = await lookupWithAutoExpand({
         pricingPlan,
         lat,
         lng,
@@ -290,7 +300,7 @@ export async function POST(request: NextRequest) {
     }
 
     const lookupDiagnostics = createLookupDiagnostics();
-    const results = await lookupWithPricingPlan({
+    const results = await lookupWithAutoExpand({
       pricingPlan,
       lat,
       lng,

--- a/components/FilterBar.tsx
+++ b/components/FilterBar.tsx
@@ -12,6 +12,7 @@ interface FilterBarProps {
 
 export function FilterBar({ results, onFilteredResults }: FilterBarProps) {
   const [sort, setSort] = useState<SortOption>("distance");
+  const [radius, setRadius] = useState<number>(25);
   const [maxPrice, setMaxPrice] = useState<number | null>(null);
   const [payers, setPayers] = useState<Payer[]>([]);
   const [selectedPayer, setSelectedPayer] = useState<string>("");
@@ -33,6 +34,10 @@ export function FilterBar({ results, onFilteredResults }: FilterBarProps) {
 
   useEffect(() => {
     let filtered = [...results];
+
+    filtered = filtered.filter(
+      (r) => r.distanceMiles == null || r.distanceMiles <= radius
+    );
 
     if (maxPrice != null) {
       filtered = filtered.filter(
@@ -58,13 +63,13 @@ export function FilterBar({ results, onFilteredResults }: FilterBarProps) {
     });
 
     onFilteredResults(filtered);
-  }, [results, sort, maxPrice, onFilteredResults]);
+  }, [results, sort, radius, maxPrice, onFilteredResults]);
 
   const handleSortChange = (newSort: SortOption) => {
     setSort(newSort);
   };
 
-  const hasFilters = maxPrice != null || selectedPayer;
+  const hasFilters = maxPrice != null || selectedPayer || radius !== 25;
 
   const selectStyles = {
     background: "var(--cc-surface)",
@@ -91,6 +96,21 @@ export function FilterBar({ results, onFilteredResults }: FilterBarProps) {
 
   return (
     <div className="flex flex-wrap items-center gap-3 py-3">
+      <div className="flex items-center gap-1.5">
+        <span style={labelStyles}>Within</span>
+        <select
+          value={radius}
+          onChange={(e) => setRadius(Number(e.target.value))}
+          style={selectStyles}
+        >
+          <option value={10}>10 mi</option>
+          <option value={25}>25 mi</option>
+          <option value={50}>50 mi</option>
+          <option value={100}>100 mi</option>
+          <option value={250}>250 mi</option>
+        </select>
+      </div>
+
       <div className="flex items-center gap-1.5">
         <span style={labelStyles}>Sort</span>
         <select
@@ -145,6 +165,7 @@ export function FilterBar({ results, onFilteredResults }: FilterBarProps) {
       {hasFilters && (
         <button
           onClick={() => {
+            setRadius(25);
             setMaxPrice(null);
             setSelectedPayer("");
           }}


### PR DESCRIPTION
## Summary
- Server fetch radius increased from 25mi → 100mi, with auto-expand to 250mi when <3 results (handles rural/sparse areas)
- New "Within" dropdown in FilterBar (10/25/50/100/250 mi) filters client-side for instant response
- "Clear filters" resets radius to default 25mi

Closes #15

## Test plan
- [ ] Search a metro area (e.g., "knee MRI" near NYC) — verify radius dropdown appears, default 25mi shows results, 10mi reduces, 100mi expands instantly
- [ ] Search a rural area (e.g., small Montana town) — verify auto-expand returns results even if sparse at 100mi
- [ ] Change radius while sort/price filters active — verify they compose correctly
- [ ] Click "Clear filters" — verify radius resets to 25mi

🤖 Generated with [Claude Code](https://claude.com/claude-code)