### PR TITLE
Add low result count handling with expand radius button

### DIFF
--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useMemo } from "react";
+import { Suspense, useCallback, useMemo } from "react";
 import { SearchBar } from "@/components/SearchBar";
 import { ResultsList } from "@/components/ResultsList";
 import { FilterBar } from "@/components/FilterBar";
@@ -8,6 +8,8 @@ import { MapView } from "@/components/MapView";
 import { SaveButton } from "@/components/SaveButton";
 import { useResultsSearch } from "./useResultsSearch";
 import { useResultSelection } from "./useResultSelection";
+
+const RADIUS_TIERS = [10, 25, 50, 100, 250];
 
 function ResultsContent() {
   const {
@@ -26,7 +28,17 @@ function ResultsContent() {
     setView,
     handleNewSearch,
     handleFilteredResults,
+    radius,
+    handleRadiusChange,
   } = useResultsSearch();
+
+  const handleExpandRadius = useCallback(() => {
+    const currentIndex = RADIUS_TIERS.indexOf(radius);
+    const nextIndex = currentIndex === -1
+      ? RADIUS_TIERS.indexOf(RADIUS_TIERS.find((t) => t > radius) ?? 250)
+      : Math.min(currentIndex + 1, RADIUS_TIERS.length - 1);
+    handleRadiusChange(RADIUS_TIERS[nextIndex]);
+  }, [radius, handleRadiusChange]);
 
   const { selectedResultId, handleMarkerClick } = useResultSelection();
 
@@ -177,6 +189,8 @@ function ResultsContent() {
             <FilterBar
               results={results}
               onFilteredResults={handleFilteredResults}
+              radius={radius}
+              onRadiusChange={handleRadiusChange}
             />
           )}
         </div>
@@ -197,6 +211,8 @@ function ResultsContent() {
               loading={loading}
               selectedResultId={selectedResultId}
               codeDescriptionMap={codeDescriptionMap}
+              locationDisplay={locationDisplay}
+              onExpandRadius={radius < 250 ? handleExpandRadius : undefined}
             />
           </div>
 

--- a/app/results/useResultsSearch.ts
+++ b/app/results/useResultsSearch.ts
@@ -78,6 +78,7 @@ export function useResultsSearch() {
   const [loadingStage, setLoadingStage] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [view, setView] = useState<"list" | "map">("list");
+  const [radius, setRadius] = useState<number>(25);
 
   useEffect(() => {
     if ((!query && directCodeGroups.length === 0 && directCodes.length === 0) || !lat || !lng) return;
@@ -188,6 +189,10 @@ export function useResultsSearch() {
     setFilteredResults(filtered);
   }, []);
 
+  const handleRadiusChange = useCallback((newRadius: number) => {
+    setRadius(newRadius);
+  }, []);
+
   return {
     query,
     lat,
@@ -205,5 +210,7 @@ export function useResultsSearch() {
     setView,
     handleNewSearch,
     handleFilteredResults,
+    radius,
+    handleRadiusChange,
   };
 }

--- a/components/FilterBar.tsx
+++ b/components/FilterBar.tsx
@@ -8,11 +8,15 @@ export type SortOption = "price-asc" | "price-desc" | "estimated-total" | "dista
 interface FilterBarProps {
   results: ChargeResult[];
   onFilteredResults: (filtered: ChargeResult[]) => void;
+  radius?: number;
+  onRadiusChange?: (radius: number) => void;
 }
 
-export function FilterBar({ results, onFilteredResults }: FilterBarProps) {
+export function FilterBar({ results, onFilteredResults, radius: controlledRadius, onRadiusChange }: FilterBarProps) {
   const [sort, setSort] = useState<SortOption>("distance");
-  const [radius, setRadius] = useState<number>(25);
+  const [internalRadius, setInternalRadius] = useState<number>(25);
+  const radius = controlledRadius ?? internalRadius;
+  const setRadius = onRadiusChange ?? setInternalRadius;
   const [maxPrice, setMaxPrice] = useState<number | null>(null);
   const [payers, setPayers] = useState<Payer[]>([]);
   const [selectedPayer, setSelectedPayer] = useState<string>("");

--- a/components/ResultsList.tsx
+++ b/components/ResultsList.tsx
@@ -8,9 +8,11 @@ interface ResultsListProps {
   loading?: boolean;
   selectedResultId?: string | null;
   codeDescriptionMap?: Record<string, string>;
+  locationDisplay?: string;
+  onExpandRadius?: () => void;
 }
 
-export function ResultsList({ results, loading, selectedResultId, codeDescriptionMap }: ResultsListProps) {
+export function ResultsList({ results, loading, selectedResultId, codeDescriptionMap, locationDisplay, onExpandRadius }: ResultsListProps) {
   if (loading) {
     return (
       <div className="space-y-3">
@@ -87,11 +89,23 @@ export function ResultsList({ results, loading, selectedResultId, codeDescriptio
           <path d="M8 11h6" />
         </svg>
         <p className="font-medium" style={{ color: "var(--cc-text-secondary)" }}>
-          No results found
+          No results found{locationDisplay ? ` near ${locationDisplay}` : ""}
         </p>
         <p className="text-sm mt-1" style={{ color: "var(--cc-text-tertiary)" }}>
-          Try adjusting your search or expanding your location radius.
+          Try a larger search radius or a different location.
         </p>
+        {onExpandRadius && (
+          <button
+            onClick={onExpandRadius}
+            className="mt-3 text-sm font-medium px-4 py-2 rounded-lg transition-colors"
+            style={{
+              color: "var(--cc-primary)",
+              background: "var(--cc-primary-light)",
+            }}
+          >
+            Expand search area
+          </button>
+        )}
       </div>
     );
   }
@@ -104,15 +118,30 @@ export function ResultsList({ results, loading, selectedResultId, codeDescriptio
 
       {results.length < 3 && (
         <div
-          className="p-3 rounded-xl border text-sm"
+          className="p-3 rounded-xl border text-sm flex items-center justify-between gap-3"
           style={{
             background: "var(--cc-accent-light)",
             borderColor: "rgba(217, 119, 6, 0.2)",
             color: "var(--cc-accent)",
           }}
         >
-          Limited pricing data available for this area. Try expanding your
-          search radius or searching in a nearby metro area.
+          <span>
+            Only {results.length} result{results.length !== 1 ? "s" : ""} found
+            within your search radius. Try expanding your search area for more
+            options.
+          </span>
+          {onExpandRadius && (
+            <button
+              onClick={onExpandRadius}
+              className="shrink-0 text-xs font-semibold px-3 py-1.5 rounded-lg transition-colors"
+              style={{
+                color: "var(--cc-accent)",
+                background: "rgba(217, 119, 6, 0.12)",
+              }}
+            >
+              Expand radius
+            </button>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary

- **0 results**: Shows "No results found near {location}" with teal "Expand search area" button
- **1-2 results**: Amber banner "Only {n} result(s) found within your search radius" with "Expand radius" button
- Expand button steps through radius tiers (10→25→50→100→250), hidden at max
- Lifts radius state from FilterBar into `useResultsSearch` hook so ResultsList can trigger radius changes
- FilterBar accepts optional controlled `radius`/`onRadiusChange` props (backwards-compatible)

## Test plan

- [ ] Search common procedure in major metro → 3+ results, no banner
- [ ] Search niche procedure or rural area → 1-2 results with amber banner + expand button
- [ ] Click "Expand radius" → FilterBar dropdown updates, more results appear
- [ ] 0 results after filtering → empty state shows location name + expand button
- [ ] At 250mi radius → expand button disappears
- [ ] FilterBar "Clear filters" resets radius to 25mi

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)