### PR TITLE
docs: close out data quality sprint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,5 +58,8 @@ lib/data/import-progress.json
 # logs
 import.log
 
+# QA screenshots (local reference only)
+docs/qa-screenshots/
+
 # scratch files
 Untitled

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,8 @@ lib/
   cpt/                — Translation logic (prompts.ts, translate.ts, lookup.ts)
   data/               — Import pipeline, code lists, DuckDB/Parquet data
   supabase/           — Three Supabase clients (browser, server, middleware)
-scripts/              — DB migration utilities (full-migration.sql, run-migration-api.ts)
+scripts/              — DB migration utilities + one-time audit/fix scripts from data quality phase
+#                       Active/reusable: db-audit.ts, stability-smoke.ts
 types/index.ts        — All shared TypeScript interfaces
 supabase/schema.sql   — Full database schema (tables, RPC functions, indexes, RLS)
 ```
@@ -174,21 +175,21 @@ Schema is in `supabase/schema.sql`. Project ref: `rzfelzmkdbicrfghofyf`.
 - 6,039 hospitals total (5,419 with complete data)
 - 274 million standard_charges rows, 6 billion payer-specific detail rows
 - Local storage: 81GB Parquet files + 11MB DuckDB index in `lib/data/`
-- Import filters to 1,002 curated codes, all settings, national scope → ~13.1M rows
+- Import filters to 1,002 curated codes, all settings, national scope → ~8.15M rows (after dedup)
 
 ### Import Details
 
-Import pipeline uses `import-trilliant.ts` (Node.js INSERT via Supabase pooler port 6543). MVP imports ~4.8% of full Oria dataset (1,002 codes × all settings → ~13.1M rows). Setting filter was removed — code list is the quality gate. See `docs/prd.md` Section 4.2.1 for data scope breakdown.
+Import pipeline uses `import-trilliant.ts` (Node.js INSERT via Supabase pooler port 6543). MVP imports ~4.8% of full Oria dataset (1,002 codes × all settings → ~8.15M rows after dedup). Setting filter was removed — code list is the quality gate. See `docs/prd.md` Section 4.2.1 for data scope breakdown.
 
 **Full import reference** (flags, DuckDB quirks, resume workflow, gotchas): see `docs/import-reference.md`
 
 ## Current Status
 
-**Phases 1-5.6 complete. Data import complete. Deployed to Vercel.**
+**Phases 1-5.6 complete. Data quality sprint complete. Deployed to Vercel.**
 
 - **Live URL:** https://clearcost-orcin.vercel.app
 - Search pipeline working end-to-end. See `docs/data-snapshot.md` for current numbers.
-- **Current phase:** Data quality — resolving issues discovered during initial frontend work
+- **Current phase:** Frontend polish (#13–#19)
 - **Work tracking:** GitHub Issues are the source of truth (issue # = priority)
 
 ## Environment Variables
@@ -292,18 +293,18 @@ gh issue create --title "..." --body "..." \
 
 ## Product Roadmap
 
-| Phase                | What                                                                                      | Status      |
-| -------------------- | ----------------------------------------------------------------------------------------- | ----------- |
-| **Phases 1-5 (MVP)** | Cash prices + aggregated payer stats, national scope, 1,002 codes                         | Complete    |
-| **Phase 5.5**        | Guided Search — AI diagnostic clarification flow + UX polish                              | Complete    |
-| **Phase 5.6**        | Results page — split view, setting filter removal, search optimization, codebase refactor | Complete    |
-| **Data Quality**     | Unknown-state providers, geocode backfill, dedup, pipeline hardening (#6-#12)             | In Progress |
-| **Frontend Polish**  | Skeletons, billing callouts, distance filter, mobile UX (#13-#19)                         | Planned     |
-| **Pre-Launch**       | Security headers, rate limiting, verification checklist (#20-#23)                         | Planned     |
-| **Phase 6**          | Independent MRF crawler (replace Trilliant dependency)                                    | Deferred    |
-| **Phase 7**          | Plan-level insurance pricing from hospital MRFs                                           | Future      |
-| **Phase 8**          | Payer Transparency in Coverage data — all provider types                                  | Future      |
-| **Phase 9**          | Non-hospital cash prices (crowdsourced/partnerships/state data)                           | Future      |
+| Phase                | What                                                                                      | Status   |
+| -------------------- | ----------------------------------------------------------------------------------------- | -------- |
+| **Phases 1-5 (MVP)** | Cash prices + aggregated payer stats, national scope, 1,002 codes                         | Complete |
+| **Phase 5.5**        | Guided Search — AI diagnostic clarification flow + UX polish                              | Complete |
+| **Phase 5.6**        | Results page — split view, setting filter removal, search optimization, codebase refactor | Complete |
+| **Data Quality**     | Unknown-state providers, geocode backfill, dedup, pipeline hardening (#6-#12)             | Complete |
+| **Frontend Polish**  | Skeletons, billing callouts, distance filter, mobile UX (#13-#19)                         | Planned  |
+| **Pre-Launch**       | Security headers, rate limiting, verification checklist (#20-#23)                         | Planned  |
+| **Phase 6**          | Independent MRF crawler (replace Trilliant dependency)                                    | Deferred |
+| **Phase 7**          | Plan-level insurance pricing from hospital MRFs                                           | Future   |
+| **Phase 8**          | Payer Transparency in Coverage data — all provider types                                  | Future   |
+| **Phase 9**          | Non-hospital cash prices (crowdsourced/partnerships/state data)                           | Future   |
 
 **Future UX enhancements** (tracked as backlog issues #32-#37):
 

--- a/scripts/investigate-missing-city.ts
+++ b/scripts/investigate-missing-city.ts
@@ -1,0 +1,144 @@
+/**
+ * Investigate providers missing city data.
+ * Usage: npx tsx --env-file=.env.local scripts/investigate-missing-city.ts
+ */
+import { createClient } from "@supabase/supabase-js";
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  { auth: { persistSession: false, autoRefreshToken: false } }
+);
+
+async function main() {
+  // 1. Count providers missing city (NULL or empty)
+  const { count: nullCity } = await supabase
+    .from("providers")
+    .select("id", { count: "exact", head: true })
+    .or("city.is.null,city.eq.");
+
+  // 2. Count providers with literal "null" string in city
+  const { count: literalNullCity } = await supabase
+    .from("providers")
+    .select("id", { count: "exact", head: true })
+    .eq("city", "null");
+
+  // 3. Count providers with literal "null" in other fields
+  const { count: literalNullState } = await supabase
+    .from("providers")
+    .select("id", { count: "exact", head: true })
+    .eq("state", "null");
+
+  const { count: literalNullAddress } = await supabase
+    .from("providers")
+    .select("id", { count: "exact", head: true })
+    .eq("address", "null");
+
+  const { count: literalNullZip } = await supabase
+    .from("providers")
+    .select("id", { count: "exact", head: true })
+    .eq("zip", "null");
+
+  console.log("\n=== Literal 'null' string analysis ===");
+  console.log(`city = 'null':    ${literalNullCity}`);
+  console.log(`state = 'null':   ${literalNullState}`);
+  console.log(`address = 'null': ${literalNullAddress}`);
+  console.log(`zip = 'null':     ${literalNullZip}`);
+
+  console.log("\n=== NULL/empty city ===");
+  console.log(`city IS NULL or empty: ${nullCity}`);
+
+  // 4. Sample providers missing city — check what other fields they have
+  const { data: sample } = await supabase
+    .from("providers")
+    .select("id,name,address,city,state,zip,lat,lng")
+    .or("city.is.null,city.eq.,city.eq.null")
+    .limit(20);
+
+  console.log("\n=== Sample providers missing city (first 20) ===");
+  for (const p of sample ?? []) {
+    console.log(
+      `  ${p.name?.slice(0, 40)?.padEnd(42)} | addr=${p.address?.slice(0, 30) ?? "NULL"} | city=${p.city ?? "NULL"} | st=${p.state ?? "NULL"} | zip=${p.zip ?? "NULL"} | lat=${p.lat != null ? "YES" : "NO"} | lng=${p.lng != null ? "YES" : "NO"}`
+    );
+  }
+
+  // 5. How many missing-city providers have charges?
+  const { data: missingCityIds } = await supabase
+    .from("providers")
+    .select("id")
+    .or("city.is.null,city.eq.,city.eq.null");
+
+  if (missingCityIds) {
+    // Check in batches of 100
+    let withCharges = 0;
+    let withoutCharges = 0;
+    const batchSize = 100;
+    for (let i = 0; i < missingCityIds.length; i += batchSize) {
+      const batch = missingCityIds.slice(i, i + batchSize).map((r) => r.id);
+      const { count } = await supabase
+        .from("charges")
+        .select("id", { count: "exact", head: true })
+        .in("provider_id", batch);
+      if (count && count > 0) {
+        // Count individual providers with charges in this batch
+        for (const pid of batch) {
+          const { count: pCount } = await supabase
+            .from("charges")
+            .select("id", { count: "exact", head: true })
+            .eq("provider_id", pid)
+            .limit(1);
+          if (pCount && pCount > 0) withCharges++;
+          else withoutCharges++;
+        }
+      } else {
+        withoutCharges += batch.length;
+      }
+    }
+    console.log(`\n=== Missing-city providers with charges ===`);
+    console.log(`Total missing city: ${missingCityIds.length}`);
+    console.log(`With charges:    ${withCharges}`);
+    console.log(`Without charges: ${withoutCharges}`);
+  }
+
+  // 6. How many have coordinates despite missing city?
+  const { count: missingCityWithCoords } = await supabase
+    .from("providers")
+    .select("id", { count: "exact", head: true })
+    .or("city.is.null,city.eq.,city.eq.null")
+    .not("lat", "is", null)
+    .not("lng", "is", null);
+
+  const { count: missingCityWithoutCoords } = await supabase
+    .from("providers")
+    .select("id", { count: "exact", head: true })
+    .or("city.is.null,city.eq.,city.eq.null")
+    .or("lat.is.null,lng.is.null");
+
+  console.log(`\n=== Missing-city providers: geocoding status ===`);
+  console.log(`With coordinates:    ${missingCityWithCoords}`);
+  console.log(`Without coordinates: ${missingCityWithoutCoords}`);
+
+  // 7. State distribution of missing-city providers
+  const { data: stateDist } = await supabase
+    .from("providers")
+    .select("state")
+    .or("city.is.null,city.eq.,city.eq.null");
+
+  if (stateDist) {
+    const stateMap = new Map<string, number>();
+    for (const row of stateDist) {
+      const st = row.state ?? "(NULL)";
+      stateMap.set(st, (stateMap.get(st) ?? 0) + 1);
+    }
+    const sorted = [...stateMap.entries()].sort((a, b) => b[1] - a[1]);
+    console.log(`\n=== Missing-city providers by state (top 15) ===`);
+    for (const [state, count] of sorted.slice(0, 15)) {
+      console.log(`  ${state.padEnd(8)} ${count}`);
+    }
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Updates CLAUDE.md to reflect data quality sprint completion (charge count, phase status, roadmap)
- Adds `.gitignore` entry for QA screenshots directory
- Adds `scripts/investigate-missing-city.ts` diagnostic script (supports #57)
- Includes audit RPC timeout fix from earlier commit (`e1b922e`)

## Context
Issue #12 asked to commit all data quality work in logical chunks. The heavy lifting was done in PRs #58, #60, #61, #62. This PR handles the remaining housekeeping: documentation updates and a diagnostic script.

Closes #12

## Test plan
- [ ] Verify CLAUDE.md Current Status reflects "data quality sprint complete" + "frontend polish" phase
- [ ] Verify roadmap table shows Data Quality = Complete
- [ ] Verify `docs/qa-screenshots/` is gitignored
- [ ] Verify `scripts/investigate-missing-city.ts` runs: `npx tsx --env-file=.env.local scripts/investigate-missing-city.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)