### PR TITLE
Remove non-functional payer filter

### DIFF
--- a/components/FilterBar.tsx
+++ b/components/FilterBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import type { ChargeResult, Payer } from "@/types";
+import type { ChargeResult } from "@/types";
 
 export type SortOption =
   | "price-asc"
@@ -28,24 +28,6 @@ export function FilterBar({
   const radius = controlledRadius ?? internalRadius;
   const setRadius = onRadiusChange ?? setInternalRadius;
   const [maxPrice, setMaxPrice] = useState<number | null>(null);
-  const [payers, setPayers] = useState<Payer[]>([]);
-  const [selectedPayer, setSelectedPayer] = useState<string>("");
-
-  useEffect(() => {
-    const fetchPayers = async () => {
-      try {
-        const response = await fetch("/api/payers");
-        if (response.ok) {
-          const data = await response.json();
-          setPayers(data);
-        }
-      } catch {
-        // Silently fail — payer filter just won't be available
-      }
-    };
-    fetchPayers();
-  }, []);
-
   useEffect(() => {
     let filtered = [...results];
 
@@ -86,7 +68,7 @@ export function FilterBar({
     setSort(newSort);
   };
 
-  const hasFilters = maxPrice != null || selectedPayer || radius !== 25;
+  const hasFilters = maxPrice != null || radius !== 25;
 
   const selectStyles = {
     background: "var(--cc-surface)",
@@ -161,30 +143,11 @@ export function FilterBar({
         </select>
       </div>
 
-      {payers.length > 0 && (
-        <div className="flex items-center gap-1.5">
-          <span style={labelStyles}>Insurance</span>
-          <select
-            value={selectedPayer}
-            onChange={(e) => setSelectedPayer(e.target.value)}
-            style={selectStyles}
-          >
-            <option value="">Cash / Self-Pay</option>
-            {payers.map((payer) => (
-              <option key={payer.id} value={payer.name}>
-                {payer.displayName}
-              </option>
-            ))}
-          </select>
-        </div>
-      )}
-
       {hasFilters && (
         <button
           onClick={() => {
             setRadius(25);
             setMaxPrice(null);
-            setSelectedPayer("");
           }}
           className="text-xs font-medium px-2.5 py-1.5 rounded-lg transition-colors hover:bg-[var(--cc-surface-alt)] hover:text-[var(--cc-text-secondary)]"
           style={{

--- a/types/index.ts
+++ b/types/index.ts
@@ -135,13 +135,6 @@ export interface PayerRate {
   methodology?: string;
 }
 
-// -- Payer (canonical payer for UI dropdown) --
-export interface Payer {
-  id: string;
-  name: string;
-  displayName: string;
-}
-
 // -- Search Query (user input) --
 export interface SearchQuery {
   query: string;


### PR DESCRIPTION
## Summary
- Removed the payer/insurance dropdown from `FilterBar` — it rendered and fetched payer names but selecting a payer had no effect on results (`selectedPayer` was never wired into the filtering `useEffect`)
- Removed the dead `Payer` interface from `types/index.ts` (only consumer was FilterBar)
- `/api/payers` endpoint preserved for Phase 7 when plan-level insurance data is available

## Test plan
- [ ] FilterBar renders with three filters: Within (radius), Sort, Max price
- [ ] No "Insurance" dropdown visible
- [ ] Clear filters button appears/works for non-default radius or maxPrice
- [ ] `npm run lint` passes with zero errors
- [ ] `/api/payers` endpoint still responds (unchanged)

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)