### PR TITLE
Refactor MapView optionsSet to useRef

### DIFF
--- a/components/MapView.tsx
+++ b/components/MapView.tsx
@@ -12,8 +12,6 @@ interface MapViewProps {
   className?: string;
 }
 
-let optionsSet = false;
-
 function buildInfoWindowContent(result: ChargeResult): string {
   const address = result.provider.address || result.provider.city || "";
   const price = result.cashPrice ? `$${result.cashPrice.toLocaleString()}` : "";
@@ -100,6 +98,7 @@ export function MapView({
   className,
 }: MapViewProps) {
   const mapRef = useRef<HTMLDivElement>(null);
+  const optionsSetRef = useRef(false);
   const [map, setMap] = useState<google.maps.Map | null>(null);
   const [error, setError] = useState<string | null>(null);
   const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
@@ -109,9 +108,9 @@ export function MapView({
   useEffect(() => {
     if (!apiKey || map || !mapRef.current) return;
 
-    if (!optionsSet) {
+    if (!optionsSetRef.current) {
       setOptions({ key: apiKey, v: "weekly" });
-      optionsSet = true;
+      optionsSetRef.current = true;
     }
 
     let cancelled = false;


### PR DESCRIPTION
## Summary

- Replaced module-level `let optionsSet` flag with `useRef(false)` inside the MapView component
- Scopes the one-time Google Maps `setOptions()` guard to the component instance instead of module scope
- Verified no straggler imports of removed `PriceResult` / `NegotiatedRate` type aliases

Closes #18

## Test plan

- [ ] Verify map renders correctly on results page (list/map toggle)
- [ ] Confirm markers appear with correct numbering and positioning
- [ ] Toggle between list and map view multiple times — map should reinitialize correctly
- [ ] `npm run lint` passes with no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)