### PR TITLE
Add security headers with CSP in report-only mode

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,7 @@ const cspDirectives: Record<string, string[]> = {
     "'unsafe-inline'",
     "'unsafe-eval'",
     "https://maps.googleapis.com",
+    "https://maps.gstatic.com",
   ],
   "style-src": ["'self'", "'unsafe-inline'"],
   "img-src": [
@@ -26,6 +27,8 @@ const cspDirectives: Record<string, string[]> = {
     "https://*.supabase.co",
     "wss://*.supabase.co",
     "https://maps.googleapis.com",
+    "https://*.googleapis.com",
+    "https://*.gstatic.com",
   ],
   "frame-src": ["'none'"],
   "object-src": ["'none'"],


### PR DESCRIPTION
## Summary
- Adds 7 security headers to all routes via `next.config.ts` `headers()` function
- CSP starts in **report-only mode** (`Content-Security-Policy-Report-Only`) to catch violations before enforcing
- CSP allowlists Google Maps domains (script, connect, img) and Supabase (connect, form-action)
- Non-CSP headers enforced immediately: HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, X-DNS-Prefetch-Control

## Follow-up
After monitoring for CSP violations in production, flip `IS_CSP_REPORT_ONLY` to `false` in a follow-up PR.

## Test plan
- [ ] `npm run build` passes (CI validates this)
- [ ] DevTools → Network: verify all 7 headers present on document responses
- [ ] DevTools → Console: check for `[Report Only]` CSP violations
- [ ] Test flows: homepage search, guided search, results + map view, Google OAuth, saved searches
- [ ] `curl -I https://clearcost-orcin.vercel.app` after deploy to confirm headers in production

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)