### PR TITLE
Add rate limiting on AI-powered API routes

### DIFF
--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,75 @@
+import { type NextRequest } from "next/server";
+
+// Requests per 60-second window, keyed by API path
+const RATE_LIMITS: Record<string, number> = {
+  "/api/search": 100,
+  "/api/cpt": 50,
+  "/api/clarify": 50,
+};
+
+const WINDOW_MS = 60_000;
+
+// Module-level window — shared across all requests in a single isolate
+let currentWindow = {
+  counts: new Map<string, number>(),
+  expiresAt: Date.now() + WINDOW_MS,
+};
+
+type RateLimitResult =
+  | { blocked: true; headers: Record<string, string>; retryAfterMs: number }
+  | { blocked: false; headers: Record<string, string> };
+
+/**
+ * Check rate limit for a request. Returns null if the path isn't rate-limited,
+ * otherwise returns the decision with pre-built response headers.
+ */
+export function applyRateLimit(request: NextRequest): RateLimitResult | null {
+  const limit = RATE_LIMITS[request.nextUrl.pathname];
+  if (limit === undefined) return null;
+
+  const now = Date.now();
+
+  // Reset the entire window when expired
+  if (now >= currentWindow.expiresAt) {
+    currentWindow = { counts: new Map(), expiresAt: now + WINDOW_MS };
+  }
+
+  const ip = getClientIp(request);
+  const key = `${ip}:${request.nextUrl.pathname}`;
+  const count = currentWindow.counts.get(key) ?? 0;
+  const resetAt = currentWindow.expiresAt;
+
+  if (count >= limit) {
+    return {
+      blocked: true,
+      headers: buildHeaders(limit, 0, resetAt, now),
+      retryAfterMs: Math.max(0, resetAt - now),
+    };
+  }
+
+  currentWindow.counts.set(key, count + 1);
+  return {
+    blocked: false,
+    headers: buildHeaders(limit, limit - count - 1, resetAt, now),
+  };
+}
+
+function getClientIp(request: NextRequest): string {
+  const forwarded = request.headers.get("x-forwarded-for");
+  if (forwarded) return forwarded.split(",")[0].trim();
+  return request.headers.get("x-real-ip") ?? "unknown";
+}
+
+function buildHeaders(
+  limit: number,
+  remaining: number,
+  resetAt: number,
+  now: number
+): Record<string, string> {
+  return {
+    "X-RateLimit-Limit": String(limit),
+    "X-RateLimit-Remaining": String(remaining),
+    "X-RateLimit-Reset": String(Math.ceil(resetAt / 1000)),
+    "Retry-After": String(Math.max(1, Math.ceil((resetAt - now) / 1000))),
+  };
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,8 +1,27 @@
 import { updateSession } from "@/lib/supabase/middleware";
-import { type NextRequest } from "next/server";
+import { applyRateLimit } from "@/lib/rate-limit";
+import { NextResponse, type NextRequest } from "next/server";
 
 export async function middleware(request: NextRequest) {
-  return await updateSession(request);
+  const rateLimit = applyRateLimit(request);
+
+  if (rateLimit?.blocked) {
+    return NextResponse.json(
+      {
+        error: "Too many requests. Please wait a moment and try again.",
+        retryAfterMs: rateLimit.retryAfterMs,
+      },
+      { status: 429, headers: rateLimit.headers }
+    );
+  }
+
+  const response = await updateSession(request);
+  if (rateLimit) {
+    for (const [key, value] of Object.entries(rateLimit.headers)) {
+      response.headers.set(key, value);
+    }
+  }
+  return response;
 }
 
 export const config = {


### PR DESCRIPTION
## Summary
- Adds fixed-window (60s) in-memory rate limiter in Next.js middleware for the three Claude API-backed routes: `/api/search` (100 req/min), `/api/cpt` (50 req/min), `/api/clarify` (50 req/min)
- Blocked requests return 429 JSON with `Retry-After` and `X-RateLimit-*` headers before reaching auth refresh or route handlers — zero wasted compute
- Non-rate-limited routes (pages, `/api/saved`, `/api/payers`, `/api/geocode`) have zero overhead

## Design
- **In-memory Map** with full window replacement every 60s (no per-entry TTLs, no cleanup sweeps)
- **Single facade API** (`applyRateLimit(request)`) keeps middleware clean — returns `null` (skip), `{ blocked: true }` (429), or `{ blocked: false, headers }` (attach and continue)
- **Per-isolate on Vercel** — provides best-effort burst protection, not deterministic enforcement. Acceptable for MVP; upgrade path is Upstash Redis if needed

## Files
- **Created**: `lib/rate-limit.ts`
- **Modified**: `middleware.ts`

## Test plan
- [x] `npm run build` passes (no type errors, Edge Runtime compatible)
- [ ] `npm run dev` + rapid `curl` to `/api/search` → verify 429 response and headers after threshold
- [ ] Normal search flow still works (search → guided search → results)
- [ ] Non-rate-limited routes unaffected

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)