### PR TITLE
Show best available price (cash or insured estimate)

### DIFF
--- a/components/FilterBar.tsx
+++ b/components/FilterBar.tsx
@@ -2,6 +2,9 @@
 
 import { useState, useEffect } from "react";
 import type { ChargeResult } from "@/types";
+import { getDisplayPrice, getDisplayPriceAmount } from "@/lib/format";
+
+export type PriceTypeFilter = "all" | "cash";
 
 export type SortOption =
   | "price-asc"
@@ -28,6 +31,7 @@ export function FilterBar({
   const radius = controlledRadius ?? internalRadius;
   const setRadius = onRadiusChange ?? setInternalRadius;
   const [maxPrice, setMaxPrice] = useState<number | null>(null);
+  const [priceType, setPriceType] = useState<PriceTypeFilter>("all");
   const [filtersOpen, setFiltersOpen] = useState(false);
   useEffect(() => {
     let filtered = [...results];
@@ -36,22 +40,32 @@ export function FilterBar({
       (r) => r.distanceMiles == null || r.distanceMiles <= radius
     );
 
+    if (priceType === "cash") {
+      filtered = filtered.filter((r) => getDisplayPrice(r).type === "cash");
+    }
+
     if (maxPrice != null) {
-      filtered = filtered.filter(
-        (r) => r.cashPrice != null && r.cashPrice <= maxPrice
-      );
+      filtered = filtered.filter((r) => {
+        const price = getDisplayPriceAmount(r);
+        return price != null && price <= maxPrice;
+      });
     }
 
     filtered.sort((a, b) => {
       switch (sort) {
         case "price-asc":
-          return (a.cashPrice ?? Infinity) - (b.cashPrice ?? Infinity);
+          return (
+            (getDisplayPriceAmount(a) ?? Infinity) -
+            (getDisplayPriceAmount(b) ?? Infinity)
+          );
         case "price-desc":
-          return (b.cashPrice ?? 0) - (a.cashPrice ?? 0);
+          return (
+            (getDisplayPriceAmount(b) ?? 0) - (getDisplayPriceAmount(a) ?? 0)
+          );
         case "estimated-total":
           return (
-            (a.estimatedTotalMedian ?? a.cashPrice ?? Infinity) -
-            (b.estimatedTotalMedian ?? b.cashPrice ?? Infinity)
+            (a.estimatedTotalMedian ?? getDisplayPriceAmount(a) ?? Infinity) -
+            (b.estimatedTotalMedian ?? getDisplayPriceAmount(b) ?? Infinity)
           );
         case "distance":
           return (a.distanceMiles ?? Infinity) - (b.distanceMiles ?? Infinity);
@@ -63,13 +77,13 @@ export function FilterBar({
     });
 
     onFilteredResults(filtered);
-  }, [results, sort, radius, maxPrice, onFilteredResults]);
+  }, [results, sort, radius, maxPrice, priceType, onFilteredResults]);
 
   const handleSortChange = (newSort: SortOption) => {
     setSort(newSort);
   };
 
-  const hasFilters = maxPrice != null || radius !== 25;
+  const hasFilters = maxPrice != null || radius !== 25 || priceType !== "all";
 
   const selectStyles = {
     background: "var(--cc-surface)",
@@ -170,11 +184,23 @@ export function FilterBar({
             onChange={(e) => handleSortChange(e.target.value as SortOption)}
             style={selectStyles}
           >
-            <option value="price-asc">Base: Low to High</option>
-            <option value="price-desc">Base: High to Low</option>
+            <option value="price-asc">Price: Low to High</option>
+            <option value="price-desc">Price: High to Low</option>
             <option value="estimated-total">Estimated total</option>
             <option value="distance">Distance</option>
             <option value="name">Name</option>
+          </select>
+        </div>
+
+        <div className="flex items-center gap-1.5">
+          <span style={labelStyles}>Prices</span>
+          <select
+            value={priceType}
+            onChange={(e) => setPriceType(e.target.value as PriceTypeFilter)}
+            style={selectStyles}
+          >
+            <option value="all">All</option>
+            <option value="cash">Cash only</option>
           </select>
         </div>
 
@@ -201,6 +227,7 @@ export function FilterBar({
             onClick={() => {
               setRadius(25);
               setMaxPrice(null);
+              setPriceType("all");
             }}
             className="text-xs font-medium px-2.5 py-1.5 rounded-lg transition-colors hover:bg-[var(--cc-surface-alt)] hover:text-[var(--cc-text-secondary)]"
             style={{

--- a/components/MapView.tsx
+++ b/components/MapView.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { setOptions, importLibrary } from "@googlemaps/js-api-loader";
 import type { ChargeResult } from "@/types";
+import { getDisplayPrice, formatDisplayPrice } from "@/lib/format";
 
 interface MapViewProps {
   results: ChargeResult[];
@@ -14,7 +15,9 @@ interface MapViewProps {
 
 function buildInfoWindowContent(result: ChargeResult): string {
   const address = result.provider.address || result.provider.city || "";
-  const price = result.cashPrice ? `$${result.cashPrice.toLocaleString()}` : "";
+  const dp = getDisplayPrice(result);
+  const priceStr = dp.amount != null ? formatDisplayPrice(dp) : "";
+  const priceColor = dp.type === "insured" ? "#1e40af" : "#0F766E";
   const distance = result.distanceMiles
     ? `${result.distanceMiles.toFixed(1)} mi`
     : "";
@@ -23,7 +26,8 @@ function buildInfoWindowContent(result: ChargeResult): string {
     <div style="padding: 10px; max-width: 240px; font-family: system-ui, sans-serif;">
       <p style="font-weight: 600; margin: 0; color: #1A1A2E; font-size: 14px;">${result.provider.name}</p>
       ${address ? `<p style="color: #5C5C6F; font-size: 12px; margin: 4px 0 0;">${address}</p>` : ""}
-      ${price ? `<p style="font-size: 20px; font-weight: 700; color: #0F766E; margin: 8px 0 0;">${price}</p>` : ""}
+      ${priceStr ? `<p style="font-size: 20px; font-weight: 700; color: ${priceColor}; margin: 8px 0 0;">${priceStr}</p>` : ""}
+      ${dp.label ? `<p style="color: #5C5C6F; font-size: 11px; margin: 2px 0 0;">${dp.label}</p>` : ""}
       ${distance ? `<p style="color: #9B9BA8; font-size: 11px; margin: 4px 0 0;">${distance} away</p>` : ""}
     </div>
   `;

--- a/components/ResultCard.tsx
+++ b/components/ResultCard.tsx
@@ -5,6 +5,8 @@ import {
   formatDistance,
   formatDate,
   formatBillingCode,
+  getDisplayPrice,
+  formatDisplayPrice,
 } from "@/lib/format";
 import type { ChargeResult } from "@/types";
 
@@ -42,9 +44,7 @@ export function ResultCard({
   const billingCode = formatBillingCode(result);
   const distance = formatDistance(result.distanceMiles);
   const lastUpdated = formatDate(result.lastUpdated);
-  const priceLabel =
-    result.baseLabel ||
-    (result.pricingMode === "encounter_first" ? "Base estimate" : "Cash price");
+  const displayPrice = getDisplayPrice(result);
 
   const resultCode = result.cpt || result.hcpcs || result.msDrg;
   const canonicalDescription = resultCode
@@ -167,7 +167,7 @@ export function ResultCard({
 
             {/* Price column */}
             <div className="text-left sm:text-right sm:shrink-0">
-              {result.cashPrice != null ? (
+              {displayPrice.type === "cash" ? (
                 <>
                   {result.grossCharge != null &&
                     result.grossCharge > (result.cashPrice || 0) && (
@@ -182,13 +182,13 @@ export function ResultCard({
                     className="text-2xl font-bold"
                     style={{ color: "var(--cc-primary)" }}
                   >
-                    {formatPrice(result.cashPrice)}
+                    {formatDisplayPrice(displayPrice)}
                   </p>
                   <p
                     className="text-xs mt-0.5"
                     style={{ color: "var(--cc-text-tertiary)" }}
                   >
-                    {priceLabel}
+                    {displayPrice.label}
                   </p>
                   {result.baseSource === "local_fallback" && (
                     <p
@@ -199,6 +199,39 @@ export function ResultCard({
                     </p>
                   )}
                 </>
+              ) : displayPrice.type === "insured" ? (
+                <>
+                  <p
+                    className="text-2xl font-bold"
+                    style={{ color: "var(--cc-info)" }}
+                  >
+                    {formatDisplayPrice(displayPrice)}
+                    <span
+                      className="inline-block ml-1 align-middle cursor-help"
+                      title="Average rate negotiated between this hospital and insurers. Your actual cost depends on your specific plan."
+                    >
+                      <svg
+                        className="w-4 h-4 inline"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <circle cx="12" cy="12" r="10" />
+                        <path d="M12 16v-4" />
+                        <path d="M12 8h.01" />
+                      </svg>
+                    </span>
+                  </p>
+                  <p
+                    className="text-xs mt-0.5"
+                    style={{ color: "var(--cc-text-tertiary)" }}
+                  >
+                    {displayPrice.label}
+                  </p>
+                </>
               ) : (
                 <p
                   className="text-sm"
@@ -208,15 +241,17 @@ export function ResultCard({
                 </p>
               )}
 
-              {result.minPrice != null && result.maxPrice != null && (
-                <p
-                  className="text-xs mt-0.5"
-                  style={{ color: "var(--cc-text-tertiary)" }}
-                >
-                  {formatPrice(result.minPrice)} &ndash;{" "}
-                  {formatPrice(result.maxPrice)}
-                </p>
-              )}
+              {displayPrice.type === "cash" &&
+                result.minPrice != null &&
+                result.maxPrice != null && (
+                  <p
+                    className="text-xs mt-0.5"
+                    style={{ color: "var(--cc-text-tertiary)" }}
+                  >
+                    {formatPrice(result.minPrice)} &ndash;{" "}
+                    {formatPrice(result.maxPrice)}
+                  </p>
+                )}
               {result.estimatedTotalMedian != null && (
                 <p
                   className="text-xs mt-1.5"
@@ -257,31 +292,32 @@ export function ResultCard({
             style={{ borderTop: "1px solid var(--cc-border)" }}
           >
             <div className="flex items-center gap-4">
-              {result.avgNegotiatedRate != null && (
-                <div className="flex items-center gap-1.5">
-                  <span
-                    className="text-xs"
-                    style={{ color: "var(--cc-text-tertiary)" }}
-                  >
-                    Avg insured:
-                  </span>
-                  <span
-                    className="text-sm font-semibold"
-                    style={{ color: "var(--cc-info)" }}
-                  >
-                    {formatPrice(result.avgNegotiatedRate)}
-                  </span>
-                  {result.payerCount != null && result.payerCount > 0 && (
+              {displayPrice.type !== "insured" &&
+                result.avgNegotiatedRate != null && (
+                  <div className="flex items-center gap-1.5">
                     <span
                       className="text-xs"
                       style={{ color: "var(--cc-text-tertiary)" }}
                     >
-                      ({result.payerCount} payer
-                      {result.payerCount !== 1 ? "s" : ""})
+                      Avg insured:
                     </span>
-                  )}
-                </div>
-              )}
+                    <span
+                      className="text-sm font-semibold"
+                      style={{ color: "var(--cc-info)" }}
+                    >
+                      {formatPrice(result.avgNegotiatedRate)}
+                    </span>
+                    {result.payerCount != null && result.payerCount > 0 && (
+                      <span
+                        className="text-xs"
+                        style={{ color: "var(--cc-text-tertiary)" }}
+                      >
+                        ({result.payerCount} payer
+                        {result.payerCount !== 1 ? "s" : ""})
+                      </span>
+                    )}
+                  </div>
+                )}
             </div>
 
             <div

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1,6 +1,49 @@
+import type { ChargeResult } from "@/types";
+
 export function formatPrice(price: number | undefined): string {
   if (price == null) return "N/A";
   return `$${price.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
+}
+
+// -- Display price waterfall: cash → insured estimate → unavailable --
+
+export type DisplayPriceType = "cash" | "insured" | "unavailable";
+
+export interface DisplayPrice {
+  amount: number | undefined;
+  label: string;
+  type: DisplayPriceType;
+}
+
+export function getDisplayPrice(result: ChargeResult): DisplayPrice {
+  if (result.cashPrice != null) {
+    const label =
+      result.baseLabel ||
+      (result.pricingMode === "encounter_first"
+        ? "Base estimate"
+        : "Cash price");
+    return { amount: result.cashPrice, label, type: "cash" };
+  }
+  if (result.avgNegotiatedRate != null) {
+    return {
+      amount: result.avgNegotiatedRate,
+      label: "Avg insured estimate",
+      type: "insured",
+    };
+  }
+  return { amount: undefined, label: "", type: "unavailable" };
+}
+
+export function getDisplayPriceAmount(
+  result: ChargeResult
+): number | undefined {
+  return getDisplayPrice(result).amount;
+}
+
+export function formatDisplayPrice(dp: DisplayPrice): string {
+  if (dp.amount == null) return "N/A";
+  const formatted = formatPrice(dp.amount);
+  return dp.type === "insured" ? `~${formatted}` : formatted;
 }
 
 export function formatDistance(miles: number | undefined): string {


### PR DESCRIPTION
## Summary

- **Display price waterfall**: Results now show cash price when available, avg insured estimate when not, instead of "Price unavailable" for 52% of charges
- **Visual differentiation**: Cash prices in teal, insured estimates in blue with `~` prefix, info tooltip, and "Avg insured estimate" label
- **Sort/filter on best available price**: Price sorting and max-price filter now operate on whichever price is available, not just cash
- **"Cash only" toggle**: New filter dropdown lets users restrict to verified cash prices
- **Map info windows**: Show price type with color coding and label
- **Footer dedup**: Hides insured section in footer when already promoted to primary display

Closes #43

## Test plan

- [ ] Search for a common procedure (e.g., "knee MRI")
- [ ] Verify results previously showing "Price unavailable" now show `~$X,XXX` in blue with "Avg insured estimate" label and tooltip
- [ ] Verify results with cash prices still show teal pricing unchanged
- [ ] Sort by "Price: Low to High" — insured-only results intersperse by amount
- [ ] Set max price filter — insured-only results still appear when rate is under threshold
- [ ] Toggle "Cash only" — insured-only results disappear; toggle "All" — they return
- [ ] Click a map marker for an insured-only result — info window shows `~$X,XXX` with label
- [ ] Verify footer "Avg insured" section is hidden when insured rate is primary price

🤖 Generated with [Claude Code](https://claude.com/claude-code)