### PR TITLE
Add total cost-of-care context banner to results page

### DIFF
--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -6,6 +6,7 @@ import { ResultsList } from "@/components/ResultsList";
 import { FilterBar } from "@/components/FilterBar";
 import { MapView } from "@/components/MapView";
 import { SaveButton } from "@/components/SaveButton";
+import { CostContextBanner } from "@/components/CostContextBanner";
 import { useResultsSearch } from "./useResultsSearch";
 import { useResultSelection } from "./useResultSelection";
 
@@ -142,6 +143,11 @@ function ResultsContent() {
               {error}
             </p>
           </div>
+        )}
+
+        {/* Cost context banner */}
+        {!loading && results.length > 0 && (
+          <CostContextBanner cptCodes={cptCodes} results={results} />
         )}
 
         {/* Toolbar: View toggle (mobile only) + Save + Filters */}

--- a/components/CostContextBanner.tsx
+++ b/components/CostContextBanner.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { getCostContext } from "@/lib/cost-context";
+import type { CPTCode, ChargeResult } from "@/types";
+
+interface CostContextBannerProps {
+  cptCodes: CPTCode[];
+  results: ChargeResult[];
+}
+
+export function CostContextBanner({
+  cptCodes,
+  results,
+}: CostContextBannerProps) {
+  const [dismissed, setDismissed] = useState(false);
+  const context = useMemo(
+    () => getCostContext(cptCodes, results),
+    [cptCodes, results]
+  );
+
+  if (dismissed || !context) return null;
+
+  return (
+    <div
+      className="mt-4 rounded-xl border p-4 animate-fade-in"
+      style={{
+        background: "var(--cc-accent-light)",
+        borderColor: "rgba(217, 119, 6, 0.15)",
+      }}
+    >
+      <div className="flex items-start gap-2.5">
+        {/* Info icon — matches ResultCard billing_class callout */}
+        <svg
+          className="w-4 h-4 mt-0.5 shrink-0"
+          style={{ color: "var(--cc-accent)" }}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <circle cx="12" cy="12" r="10" />
+          <path d="M12 16v-4" />
+          <path d="M12 8h.01" />
+        </svg>
+
+        <p className="flex-1 text-sm" style={{ color: "var(--cc-accent)" }}>
+          {context.message}
+        </p>
+
+        {/* Dismiss button */}
+        <button
+          onClick={() => setDismissed(true)}
+          className="shrink-0 p-0.5 rounded-md hover:bg-black/5 transition-colors"
+          style={{ color: "var(--cc-accent)" }}
+          aria-label="Dismiss cost context"
+        >
+          <svg
+            className="w-4 h-4"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M18 6 6 18" />
+            <path d="M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/lib/cost-context.ts
+++ b/lib/cost-context.ts
@@ -1,0 +1,134 @@
+import type { CPTCode, ChargeResult } from "@/types";
+
+export interface CostContextMessage {
+  message: string;
+}
+
+type CostPattern =
+  | "surgery"
+  | "imaging"
+  | "cardiac"
+  | "lab"
+  | "therapy"
+  | "injection"
+  | "procedure";
+
+const MESSAGES: Record<CostPattern, string> = {
+  surgery:
+    "This is the facility/surgeon fee. Your total cost may also include anesthesia, hospital stay, and post-op rehabilitation.",
+  imaging:
+    "This is the imaging fee. A separate radiologist reading fee may also apply.",
+  cardiac:
+    "This is the test fee. A separate cardiologist interpretation fee may also apply.",
+  lab: "This is the lab test fee. A separate specimen collection or draw fee may apply.",
+  therapy:
+    "Individual session fee. Most treatment plans require multiple sessions over several weeks.",
+  injection:
+    "This is the administration fee. The drug or medication cost may be billed separately.",
+  procedure:
+    "Additional costs such as anesthesia or facility fees may apply separately.",
+};
+
+const INPATIENT_ADDENDUM =
+  " For inpatient stays, room & board and daily physician visit charges also typically apply.";
+
+// Ordered keyword rules — first match wins within each pattern
+const KEYWORD_RULES: [RegExp, CostPattern | null][] = [
+  [/surg|orthop|scopy|gastro/, "surgery"],
+  [/radio|imag|mri|ct |xray|x-ray|ultrasound|nuclear|mammog/, "imaging"],
+  [/cardi|echo|ekg|electro/, "cardiac"],
+  [/lab|patho|blood/, "lab"],
+  [/therap|rehab|physical med/, "therapy"],
+  [/inject|infus/, "injection"],
+  [/office|visit|emergency|e&m|prevent|screen|consult|evaluation/, null],
+  [/procedure/, "procedure"],
+];
+
+// Priority for resolving multiple categories (highest first)
+const PRIORITY: (CostPattern | null)[] = [
+  "surgery",
+  "imaging",
+  "cardiac",
+  "lab",
+  "therapy",
+  "injection",
+  "procedure",
+  null,
+];
+
+function matchKeyword(category: string): CostPattern | null | undefined {
+  for (const [regex, pattern] of KEYWORD_RULES) {
+    if (regex.test(category)) return pattern;
+  }
+  return undefined; // no keyword match — distinct from null (explicit E&M)
+}
+
+function matchCodeRange(code: string): CostPattern | null | undefined {
+  // HCPCS codes start with a letter — too varied for reliable mapping
+  if (/^[a-zA-Z]/.test(code)) return undefined;
+
+  const num = parseInt(code, 10);
+  if (isNaN(num)) return undefined;
+
+  if (num >= 10000 && num <= 69999) return "surgery";
+  if (num >= 70000 && num <= 79999) return "imaging";
+  if (num >= 80000 && num <= 89999) return "lab";
+  if (num >= 90000 && num <= 99199) return "procedure";
+  if (num >= 99200 && num <= 99499) return null; // E&M
+  return undefined;
+}
+
+export function getCostContext(
+  cptCodes: CPTCode[],
+  results: ChargeResult[]
+): CostContextMessage | null {
+  if (cptCodes.length === 0) return null;
+
+  // Collect unique categories, try keyword match on each
+  const matches = new Set<CostPattern | null>();
+  let anyKeywordHit = false;
+
+  for (const code of cptCodes) {
+    if (!code.category) continue;
+    const match = matchKeyword(code.category.toLowerCase());
+    if (match !== undefined) {
+      anyKeywordHit = true;
+      matches.add(match);
+    }
+  }
+
+  // Fallback: CPT code range of the first code (only if no keyword matched)
+  if (!anyKeywordHit) {
+    const firstCode = cptCodes[0]?.code;
+    if (firstCode) {
+      const rangeMatch = matchCodeRange(firstCode);
+      if (rangeMatch !== undefined) matches.add(rangeMatch);
+    }
+  }
+
+  if (matches.size === 0) return null;
+
+  // Pick highest-priority pattern
+  let bestPattern: CostPattern | null = null;
+  for (const p of PRIORITY) {
+    if (matches.has(p)) {
+      bestPattern = p;
+      break;
+    }
+  }
+
+  // null means E&M/visit — no banner
+  if (bestPattern === null) return null;
+
+  let message = MESSAGES[bestPattern];
+
+  // Append inpatient addendum for surgery/procedure when any result is inpatient
+  if (
+    (bestPattern === "surgery" || bestPattern === "procedure") &&
+    results.some((r) => r.setting === "inpatient")
+  ) {
+    message += INPATIENT_ADDENDUM;
+  }
+
+  return { message };
+}


### PR DESCRIPTION
## Summary

- Adds a dismissible amber callout banner between the interpretation banner and toolbar on the results page
- Educates users that displayed prices may not include all episode costs (anesthesia, radiologist reading fees, drug costs, specimen collection, etc.)
- Uses hybrid matching strategy: keyword match on `CPTCode.category` first, then CPT code range fallback for unrecognized categories
- 7 MECE cost-context patterns (surgery, imaging, cardiac, lab, therapy, injection, procedure) + inpatient addendum
- E&M/visit categories correctly suppressed (no banner — already all-inclusive)

## Files

| File | Change |
|------|--------|
| `lib/cost-context.ts` | NEW — Pure domain logic (~120 lines): keyword matching, code range fallback, priority resolution |
| `components/CostContextBanner.tsx` | NEW — Presentational component (~75 lines): amber banner, dismiss via useState, useMemo on getCostContext |
| `app/results/page.tsx` | Import + 4-line JSX insertion between error state and toolbar |

## Test plan

- [ ] Search "knee replacement" → Surgery banner (anesthesia, hospital stay, rehab)
- [ ] Search "knee MRI" → Imaging banner (radiologist reading fee)
- [ ] Search "EKG" or "echocardiogram" → Cardiac banner (cardiologist interpretation)
- [ ] Search "blood test" or "CBC" → Lab banner (specimen collection fee)
- [ ] Search "physical therapy" → Therapy banner (multiple sessions)
- [ ] Search "joint injection" → Injection banner (drug cost separate)
- [ ] Search "annual checkup" → No banner (E&M)
- [ ] Click X → banner disappears for current search
- [ ] New search after dismiss → banner reappears
- [ ] Inpatient surgery results → surgery msg + inpatient addendum
- [ ] Mobile responsive — banner stacks cleanly

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)