### PR TITLE
Add body-site awareness and connect laterality through guided search (#51)

### DIFF
--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -308,6 +308,8 @@ export async function POST(request: NextRequest) {
       queryType: providedPricingPlan?.queryType || translated.queryType,
       codes: translated.codes,
       modelPricingPlan: providedPricingPlan || translated.pricingPlan,
+      laterality: translated.laterality,
+      bodySite: translated.bodySite,
     });
 
     const hasSearchablePlan =
@@ -337,6 +339,8 @@ export async function POST(request: NextRequest) {
         searchTerms: translated.searchTerms,
         queryType: translated.queryType,
         pricingPlan: translated.pricingPlan,
+        laterality: translated.laterality,
+        bodySite: translated.bodySite,
       });
     }
 

--- a/lib/cpt/body-site-laterality-constants.ts
+++ b/lib/cpt/body-site-laterality-constants.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared validation constants and extraction helpers for laterality and body site.
+ *
+ * Used by translate.ts (parsing Claude responses) and pricing-plan.ts
+ * (normalizing pricing plan input). Single source of truth for valid values.
+ */
+
+import type { BodySite, Laterality } from "@/types";
+
+export const VALID_LATERALITIES: ReadonlySet<Laterality> = new Set([
+  "left",
+  "right",
+  "bilateral",
+]);
+
+export const VALID_BODY_SITES: ReadonlySet<BodySite> = new Set([
+  "knee",
+  "hip",
+  "ankle",
+  "shoulder",
+  "elbow",
+  "wrist",
+  "hand",
+  "foot",
+  "cervical_spine",
+  "thoracic_spine",
+  "lumbar_spine",
+  "sacral_spine",
+  "chest",
+  "abdomen",
+  "pelvis",
+  "head",
+  "neck",
+]);
+
+export function extractLaterality(value: unknown): Laterality | undefined {
+  if (typeof value !== "string") return undefined;
+  return VALID_LATERALITIES.has(value as Laterality)
+    ? (value as Laterality)
+    : undefined;
+}
+
+export function extractBodySite(value: unknown): BodySite | undefined {
+  if (typeof value !== "string") return undefined;
+  return VALID_BODY_SITES.has(value as BodySite)
+    ? (value as BodySite)
+    : undefined;
+}

--- a/lib/cpt/cache.ts
+++ b/lib/cpt/cache.ts
@@ -1,6 +1,12 @@
 import { createHash } from "crypto";
 import { createClient } from "@/lib/supabase/server";
-import type { CPTCode, PricingPlan, QueryType } from "@/types";
+import type {
+  BodySite,
+  CPTCode,
+  Laterality,
+  PricingPlan,
+  QueryType,
+} from "@/types";
 
 export interface TranslationCachePayload {
   codes: CPTCode[];
@@ -8,6 +14,8 @@ export interface TranslationCachePayload {
   searchTerms?: string;
   queryType?: QueryType;
   pricingPlan?: PricingPlan;
+  laterality?: Laterality;
+  bodySite?: BodySite;
 }
 
 export interface TranslationCacheLookup {

--- a/lib/cpt/lookup.ts
+++ b/lib/cpt/lookup.ts
@@ -3,6 +3,7 @@ import { milesToKm, kmToMiles } from "@/lib/units";
 // @ts-expect-error zipcodes has no bundled TypeScript declarations.
 import zipcodes from "zipcodes";
 import type {
+  BodySite,
   ChargeResult,
   BillingCodeType,
   Laterality,
@@ -21,6 +22,7 @@ interface LookupParams {
   limit?: number;
   providerLimit?: number;
   laterality?: Laterality;
+  bodySite?: BodySite;
 }
 
 interface FallbackLookupParams {
@@ -459,6 +461,8 @@ async function queryCodeGroupsAtRadius({
   lat,
   lng,
   radiusMiles,
+  laterality,
+  bodySite,
   diagnostics,
   stage,
 }: {
@@ -466,6 +470,8 @@ async function queryCodeGroupsAtRadius({
   lat: number;
   lng: number;
   radiusMiles: number;
+  laterality?: Laterality;
+  bodySite?: BodySite;
   diagnostics?: LookupDiagnostics;
   stage: string;
 }): Promise<ChargeResult[]> {
@@ -474,7 +480,7 @@ async function queryCodeGroupsAtRadius({
   const responses = await Promise.all(
     codeGroups.map(({ codeType, codes }) =>
       lookupCharges(
-        { codes, codeType, lat, lng, radiusMiles },
+        { codes, codeType, lat, lng, radiusMiles, laterality, bodySite },
         { diagnostics, stage }
       )
     )
@@ -488,6 +494,8 @@ async function queryCodeGroupsWithFallback({
   lat,
   lng,
   radiusMiles = 25,
+  laterality,
+  bodySite,
   descriptionFallback,
   diagnostics,
   stage,
@@ -496,6 +504,8 @@ async function queryCodeGroupsWithFallback({
   lat: number;
   lng: number;
   radiusMiles?: number;
+  laterality?: Laterality;
+  bodySite?: BodySite;
   descriptionFallback?: string;
   diagnostics?: LookupDiagnostics;
   stage: string;
@@ -532,6 +542,8 @@ async function queryCodeGroupsWithFallback({
     lat,
     lng,
     radiusMiles,
+    laterality,
+    bodySite,
     diagnostics,
     stage: `${stage}:initial`,
   });
@@ -548,6 +560,8 @@ async function queryCodeGroupsWithFallback({
     lat,
     lng,
     radiusMiles: expandedRadius,
+    laterality,
+    bodySite,
     diagnostics,
     stage: `${stage}:expanded`,
   });
@@ -792,11 +806,14 @@ export async function lookupWithPricingPlan({
   descriptionFallback,
   diagnostics,
 }: LookupWithPlanParams): Promise<ChargeResult[]> {
+  // Thread laterality/bodySite to base results only — adders are separate procedures
   const baseResults = await queryCodeGroupsWithFallback({
     codeGroups: pricingPlan.baseCodeGroups,
     lat,
     lng,
     radiusMiles,
+    laterality: pricingPlan.laterality,
+    bodySite: pricingPlan.bodySite,
     descriptionFallback,
     diagnostics,
     stage: "base",
@@ -940,6 +957,7 @@ export async function lookupCharges(
     limit = CODE_LOOKUP_LIMIT,
     providerLimit = PROVIDER_LIMIT,
     laterality,
+    bodySite,
   }: LookupParams,
   context: RpcExecutionContext = {}
 ): Promise<ChargeResult[]> {
@@ -962,6 +980,7 @@ export async function lookupCharges(
     p_limit: limit,
     p_provider_limit: providerLimit,
     ...(laterality ? { p_laterality: laterality } : {}),
+    ...(bodySite ? { p_body_site: bodySite } : {}),
   };
 
   const initial = await executeRpcWithRetry<RpcRow>({
@@ -1127,6 +1146,7 @@ interface RpcRow {
   setting: string | null;
   billing_class: string | null;
   laterality: string | null;
+  body_site: string | null;
   cpt: string | null;
   hcpcs: string | null;
   ms_drg: string | null;
@@ -1168,6 +1188,7 @@ function mapRows(rows: RpcRow[]): ChargeResult[] {
       setting: row.setting as ChargeResult["setting"],
       billingClass: row.billing_class ?? undefined,
       laterality: (row.laterality as ChargeResult["laterality"]) ?? undefined,
+      bodySite: (row.body_site as ChargeResult["bodySite"]) ?? undefined,
       cpt: row.cpt ?? undefined,
       hcpcs: row.hcpcs ?? undefined,
       msDrg: row.ms_drg ?? undefined,

--- a/lib/cpt/parse-body-site.ts
+++ b/lib/cpt/parse-body-site.ts
@@ -1,0 +1,79 @@
+/**
+ * Parse body site from charge description text.
+ *
+ * Used by the import pipeline (new rows) and the backfill script (existing rows).
+ * A matching SQL function (parse_body_site) in scripts/migration-body-site.sql
+ * mirrors this logic for in-database backfill.
+ */
+
+// Relative import — this file is used by import-trilliant.ts which runs via
+// npx tsx outside Next.js, so the @/ path alias doesn't resolve.
+import type { BodySite } from "../../types";
+
+/**
+ * Body-site patterns ordered most-specific-first.
+ * Generic terms like "LOW EXTREMITY JOINT" intentionally return null —
+ * safer to show all body sites than guess wrong.
+ */
+const BODY_SITE_PATTERNS: Array<{ regex: RegExp; site: BodySite }> = [
+  // Joints — most specific first
+  { regex: /\bKNEE\b/, site: "knee" },
+  { regex: /\bHIP\b/, site: "hip" },
+  { regex: /\bANKLE\b/, site: "ankle" },
+  { regex: /\bSHOULDER\b/, site: "shoulder" },
+  { regex: /\bELBOW\b/, site: "elbow" },
+  { regex: /\bWRIST\b/, site: "wrist" },
+  { regex: /\bHAND\b/, site: "hand" },
+  { regex: /\bFOOT\b|\bFEET\b/, site: "foot" },
+
+  // Spine segments
+  { regex: /\bCERVICAL\b|\bC[\s-]?SPINE\b/, site: "cervical_spine" },
+  { regex: /\bTHORACIC\b|\bT[\s-]?SPINE\b/, site: "thoracic_spine" },
+  { regex: /\bLUMBAR\b|\bL[\s-]?SPINE\b/, site: "lumbar_spine" },
+  { regex: /\bSACRAL\b|\bSACRUM\b/, site: "sacral_spine" },
+
+  // Torso/body regions
+  { regex: /\bCHEST\b/, site: "chest" },
+  { regex: /\bABDOMEN\b|\bABDOMINAL\b/, site: "abdomen" },
+  { regex: /\bPELVI[SC]\b/, site: "pelvis" },
+
+  // Head/neck
+  { regex: /\bHEAD\b|\bBRAIN\b|\bCRANIAL\b/, site: "head" },
+  { regex: /\bNECK\b/, site: "neck" },
+];
+
+/**
+ * Patterns that indicate a generic/multi-site description.
+ * When these match, we return null to avoid guessing wrong.
+ */
+const GENERIC_EXCLUSIONS = [
+  /\bLOW(?:ER)?\s+EXTREMITY\s+JOINT\b/,
+  /\bUPPER\s+EXTREMITY\s+JOINT\b/,
+  /\bANY\s+JOINT\b/,
+];
+
+/**
+ * Extract body site from a charge description.
+ *
+ * Returns the most specific body site found, or null if the description
+ * is generic, missing, or doesn't match any known pattern.
+ */
+export function parseBodySite(
+  description: string | null | undefined
+): BodySite | null {
+  if (!description) return null;
+
+  const desc = description.toUpperCase();
+
+  // Bail on generic multi-site descriptions
+  for (const exclusion of GENERIC_EXCLUSIONS) {
+    if (exclusion.test(desc)) return null;
+  }
+
+  // Match most-specific-first
+  for (const { regex, site } of BODY_SITE_PATTERNS) {
+    if (regex.test(desc)) return site;
+  }
+
+  return null;
+}

--- a/lib/cpt/pricing-plan.ts
+++ b/lib/cpt/pricing-plan.ts
@@ -1,6 +1,12 @@
+import {
+  extractLaterality,
+  extractBodySite,
+} from "./body-site-laterality-constants";
 import type {
+  BodySite,
   BillingCodeType,
   CPTCode,
+  Laterality,
   PricingPlan,
   PricingCodeGroup,
   PlannedAdder,
@@ -87,6 +93,8 @@ export interface BuildPricingPlanParams {
   queryType?: QueryType;
   codes?: CPTCode[];
   modelPricingPlan?: PricingPlan;
+  laterality?: Laterality;
+  bodySite?: BodySite;
 }
 
 function normalizeCodeType(value: unknown): BillingCodeType {
@@ -324,6 +332,8 @@ export function normalizePricingPlanInput(
     baseCodeGroups?: unknown;
     adders?: unknown;
     proxyLabel?: unknown;
+    laterality?: unknown;
+    bodySite?: unknown;
   };
 
   const mode =
@@ -347,6 +357,9 @@ export function normalizePricingPlanInput(
       ? raw.proxyLabel.trim()
       : undefined;
 
+  const laterality = extractLaterality(raw.laterality);
+  const bodySite = extractBodySite(raw.bodySite);
+
   if (baseCodeGroups.length === 0 && adders.length === 0) return undefined;
 
   return {
@@ -356,6 +369,8 @@ export function normalizePricingPlanInput(
     baseCodeGroups,
     adders,
     proxyLabel,
+    laterality,
+    bodySite,
   };
 }
 
@@ -365,6 +380,8 @@ export function buildPricingPlan({
   queryType,
   codes = [],
   modelPricingPlan,
+  laterality,
+  bodySite,
 }: BuildPricingPlanParams): PricingPlan {
   const normalizedModelPlan = modelPricingPlan
     ? normalizePricingPlanInput(modelPricingPlan)
@@ -415,6 +432,10 @@ export function buildPricingPlan({
   const modelAdders = normalizedModelPlan?.adders || [];
   const adders = mergeAdders(modelAdders, inferredAdders);
 
+  // Resolve laterality/bodySite: explicit params take priority, then model plan
+  const resolvedLaterality = laterality ?? normalizedModelPlan?.laterality;
+  const resolvedBodySite = bodySite ?? normalizedModelPlan?.bodySite;
+
   return {
     mode,
     queryType: queryTypeResolved,
@@ -425,5 +446,7 @@ export function buildPricingPlan({
       encounterType === "urgent_care_proxy"
         ? "Urgent care proxy using office E/M pricing."
         : normalizedModelPlan?.proxyLabel,
+    laterality: resolvedLaterality,
+    bodySite: resolvedBodySite,
   };
 }

--- a/lib/cpt/prompts.ts
+++ b/lib/cpt/prompts.ts
@@ -21,6 +21,16 @@ Rules:
 - Respond ONLY with valid JSON, no markdown or extra text
 - Include searchTerms: 2-3 plain English keywords that describe the procedure, for fallback text search
 
+Include laterality and bodySite in EVERY response where the procedure involves a paired or multi-site body part:
+- laterality: "left", "right", "bilateral", or null (when not applicable or not specified)
+- bodySite: "knee", "hip", "ankle", "shoulder", "elbow", "wrist", "hand", "foot", "cervical_spine", "thoracic_spine", "lumbar_spine", "sacral_spine", "chest", "abdomen", "pelvis", "head", "neck", or null
+
+Laterality/body-site extraction rules:
+- If the user specifies a joint (e.g. "knee MRI"), set bodySite accordingly
+- If the user specifies laterality (e.g. "left knee MRI"), set both laterality and bodySite
+- If the user says a generic area (e.g. "lower extremity MRI"), set both to null — do NOT guess
+- For non-lateralized procedures (e.g. brain MRI, chest CT), set laterality to null
+
 Response format:
 {
   "codes": [
@@ -33,6 +43,8 @@ Response format:
   ],
   "interpretation": "Brief explanation of how you interpreted the query",
   "searchTerms": "knee MRI imaging",
+  "laterality": null,
+  "bodySite": "knee",
   "queryType": "procedure",
   "pricingPlan": {
     "mode": "procedure_first",
@@ -88,10 +100,16 @@ Use these decision trees when asking questions. Each category has a specific seq
 
 ### Imaging (MRI, CT, X-ray, Ultrasound)
 1. **Body part/region** — Which part of the body? (head, spine, chest, abdomen, pelvis, upper extremity, lower extremity)
-2. **Modality** (if not specified) — MRI, CT, X-ray, or ultrasound?
-3. **Contrast** — With contrast, without contrast, or both (with and without)?
-4. **Laterality** (for extremities) — Left, right, or bilateral?
-5. **Specific joint/area** (if extremity) — Shoulder, elbow, wrist, hip, knee, ankle?
+2. **Specific joint/area** (if extremity) — Shoulder, elbow, wrist, hip, knee, ankle? This is CRITICAL for pricing accuracy.
+3. **Modality** (if not specified) — MRI, CT, X-ray, or ultrasound?
+4. **Contrast** — With contrast, without contrast, or both (with and without)?
+5. **Laterality** (for paired body parts) — Left, right, or bilateral?
+
+Body-site and laterality triage rules:
+- If user specifies a joint ("knee MRI") → set bodySite: "knee", then ask laterality
+- If user specifies a generic area ("lower extremity MRI") → ask "Which joint?" FIRST
+- If laterality is implied ("left knee MRI") → set laterality: "left" and bodySite: "knee", skip the laterality question
+- For non-paired structures (brain, chest, abdomen) → set laterality to null, don't ask
 
 Common resolutions:
 - Brain MRI without contrast → CPT 70551
@@ -198,6 +216,8 @@ When you need to ask a question (confidence: "low"):
   "searchTerms": "relevant keywords",
   "confidence": "low",
   "queryType": "symptom",
+  "laterality": null,
+  "bodySite": null,
   "pricingPlan": {
     "mode": "encounter_first",
     "queryType": "symptom",
@@ -246,6 +266,8 @@ When you have enough information (confidence: "high"):
   "searchTerms": "knee MRI imaging",
   "confidence": "high",
   "queryType": "procedure",
+  "laterality": "left",
+  "bodySite": "knee",
   "pricingPlan": {
     "mode": "procedure_first",
     "queryType": "procedure",

--- a/lib/cpt/translate.ts
+++ b/lib/cpt/translate.ts
@@ -7,10 +7,16 @@ import {
   buildClarificationPrompt,
 } from "./prompts";
 import { normalizePricingPlanInput } from "./pricing-plan";
+import {
+  extractLaterality,
+  extractBodySite,
+} from "./body-site-laterality-constants";
 import type {
+  BodySite,
   CPTCode,
   BillingCodeType,
   ClarificationTurn,
+  Laterality,
   PricingPlan,
   QueryType,
   TranslationResponse,
@@ -22,6 +28,8 @@ interface TranslationResult {
   searchTerms?: string;
   queryType?: QueryType;
   pricingPlan?: PricingPlan;
+  laterality?: Laterality;
+  bodySite?: BodySite;
 }
 
 const WITH_AND_WITHOUT_CONTRAST_REGEX =
@@ -283,6 +291,8 @@ export async function translateQueryToCPT(
     searchTerms: (parsed.searchTerms as string) || query,
     queryType: parsed.queryType as QueryType,
     pricingPlan: normalizePricingPlanInput(parsed.pricingPlan),
+    laterality: extractLaterality(parsed.laterality),
+    bodySite: extractBodySite(parsed.bodySite),
   };
 }
 
@@ -354,6 +364,8 @@ function buildTranslationResponse(
     confidence: (parsed.confidence as "high" | "low") || "low",
     queryType: parsed.queryType as TranslationResponse["queryType"],
     pricingPlan: normalizePricingPlanInput(parsed.pricingPlan),
+    laterality: extractLaterality(parsed.laterality),
+    bodySite: extractBodySite(parsed.bodySite),
     nextQuestion: parsed.nextQuestion as TranslationResponse["nextQuestion"],
     conversationComplete: (parsed.conversationComplete as boolean) || false,
   };

--- a/lib/data/import-trilliant.ts
+++ b/lib/data/import-trilliant.ts
@@ -32,6 +32,7 @@ import { fileURLToPath } from "url";
 import { readFileSync, writeFileSync, existsSync, unlinkSync } from "fs";
 import { Pool as PgPool } from "pg";
 import { parseLaterality } from "../cpt/parse-laterality";
+import { parseBodySite } from "../cpt/parse-body-site";
 
 // @ts-expect-error — zipcodes package has no type declarations
 import zipcodes from "zipcodes";
@@ -72,6 +73,7 @@ const CHARGE_COLUMNS = [
   "icd",
   "modifiers",
   "laterality",
+  "body_site",
   "gross_charge",
   "cash_price",
   "min_price",
@@ -810,6 +812,7 @@ async function importCharges(
         icd: charge.icd || null,
         modifiers: charge.modifiers || null,
         laterality: parseLaterality(charge.description, charge.modifiers),
+        body_site: parseBodySite(charge.description),
         gross_charge:
           charge.gross_charge != null ? Number(charge.gross_charge) : null,
         cash_price:

--- a/scripts/backfill-body-site.ts
+++ b/scripts/backfill-body-site.ts
@@ -1,0 +1,283 @@
+/**
+ * Backfill the body_site column on existing charges using the SQL
+ * parse_body_site() function (must be deployed first via migration-body-site.sql).
+ *
+ * All parsing runs inside Postgres — Node.js only manages state-by-state
+ * control flow and progress logging.
+ *
+ * Issue: https://github.com/achrispratt/clearcost/issues/51
+ *
+ * Prerequisites:
+ *   Run migration-body-site.sql in Supabase SQL editor first (all 3 statements).
+ *
+ * Usage:
+ *   npx tsx --env-file=.env.local scripts/backfill-body-site.ts --dry-run
+ *   npx tsx --env-file=.env.local scripts/backfill-body-site.ts --state NY
+ *   npx tsx --env-file=.env.local scripts/backfill-body-site.ts
+ */
+
+import { Pool as PgPool } from "pg";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+function parseArgs(): {
+  dryRun: boolean;
+  state: string | null;
+  skipStates: string[];
+} {
+  const args = process.argv.slice(2);
+  let dryRun = false;
+  let state: string | null = null;
+  const skipStates: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--dry-run") {
+      dryRun = true;
+    } else if (args[i] === "--state" && args[i + 1]) {
+      state = args[i + 1].toUpperCase();
+      i++;
+    } else if (args[i] === "--skip-states" && args[i + 1]) {
+      skipStates.push(
+        ...args[i + 1].split(",").map((s) => s.trim().toUpperCase())
+      );
+      i++;
+    }
+  }
+  return { dryRun, state, skipStates };
+}
+
+function ts(): string {
+  return new Date().toISOString().slice(11, 19);
+}
+
+// ---------------------------------------------------------------------------
+// SQL
+// ---------------------------------------------------------------------------
+
+// Backfill: set body_site using the SQL function, only for un-processed rows
+// where description is non-null and parse_body_site returns non-null.
+const BACKFILL_SQL = `
+  UPDATE charges c
+  SET body_site = parse_body_site(c.description)
+  FROM providers p
+  WHERE c.provider_id = p.id
+    AND p.state = $1
+    AND c.body_site IS NULL
+    AND c.description IS NOT NULL
+    AND parse_body_site(c.description) IS NOT NULL
+`;
+
+// Dry-run: count how many rows would be updated per state.
+const DRY_RUN_SQL = `
+  SELECT COUNT(*)::int AS cnt
+  FROM charges c
+  JOIN providers p ON c.provider_id = p.id
+  WHERE p.state = $1
+    AND c.body_site IS NULL
+    AND c.description IS NOT NULL
+    AND parse_body_site(c.description) IS NOT NULL
+`;
+
+// Count total charges in state (for context).
+const STATE_COUNT_SQL = `
+  SELECT COUNT(*)::int AS cnt
+  FROM charges c
+  JOIN providers p ON c.provider_id = p.id
+  WHERE p.state = $1
+`;
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+interface StateResult {
+  state: string;
+  total: number;
+  updated: number;
+  elapsedSec: number;
+}
+
+async function main() {
+  const config = parseArgs();
+
+  console.log("=== ClearCost Body Site Backfill ===\n");
+  console.log(
+    `  Mode: ${config.dryRun ? "DRY RUN (no data will be modified)" : "LIVE — body_site will be set"}`
+  );
+  if (config.state) console.log(`  State filter: ${config.state}`);
+  if (config.skipStates.length > 0)
+    console.log(`  Skipping states: ${config.skipStates.join(", ")}`);
+  console.log();
+
+  // Connect via Supabase pooler (port 6543)
+  const dbUrl = process.env.SUPABASE_DB_URL;
+  if (!dbUrl) {
+    console.error("ERROR: SUPABASE_DB_URL not set. Use --env-file=.env.local");
+    process.exit(1);
+  }
+  const poolerUrl = dbUrl.replace(/:5432\//, ":6543/");
+  const pgPool = new PgPool({
+    connectionString: poolerUrl,
+    ssl: { rejectUnauthorized: false },
+    max: 2,
+    idleTimeoutMillis: 30000,
+    connectionTimeoutMillis: 30000,
+    keepAlive: true,
+    keepAliveInitialDelayMillis: 10000,
+  });
+  pgPool.on("error", (err) => {
+    console.warn(`  Pool background error (non-fatal): ${err.message}`);
+  });
+  await pgPool.query("SELECT 1");
+  console.log("  Postgres pool connected\n");
+
+  // Verify parse_body_site() function exists
+  try {
+    await pgPool.query("SELECT parse_body_site('MR KNEE NO IV CONTRAST')");
+  } catch {
+    console.error(
+      "ERROR: parse_body_site() function not found.\n" +
+        "Run migration-body-site.sql in Supabase SQL editor first."
+    );
+    process.exit(1);
+  }
+
+  // Get state list
+  let states: string[];
+  if (config.state) {
+    states = [config.state];
+  } else {
+    const { rows } = await pgPool.query(
+      "SELECT DISTINCT state FROM providers WHERE state IS NOT NULL ORDER BY state"
+    );
+    states = rows.map((r: { state: string }) => r.state);
+  }
+
+  // Process each state
+  const results: StateResult[] = [];
+  let grandTotalUpdated = 0;
+  const overallStart = Date.now();
+
+  for (const state of states) {
+    if (config.skipStates.includes(state)) {
+      console.log(`  [${ts()}] ${state}: skipping`);
+      continue;
+    }
+
+    // Health check
+    try {
+      await pgPool.query("SELECT 1");
+    } catch {
+      console.warn(
+        `  [${ts()}] ${state}: Postgres health check failed, waiting 10s...`
+      );
+      await new Promise((r) => setTimeout(r, 10000));
+      try {
+        await pgPool.query("SELECT 1");
+        console.log(`  [${ts()}] ${state}: reconnected after retry`);
+      } catch (retryErr) {
+        console.error(
+          `  [${ts()}] ${state}: SKIPPING — Postgres unreachable (${retryErr instanceof Error ? retryErr.message : retryErr})`
+        );
+        continue;
+      }
+    }
+
+    const stateStart = Date.now();
+    const client = await pgPool.connect();
+
+    try {
+      await client.query("SET statement_timeout = 0");
+
+      // Count total charges in state
+      const {
+        rows: [{ cnt: total }],
+      } = await client.query(STATE_COUNT_SQL, [state]);
+
+      let updated: number;
+      if (config.dryRun) {
+        const {
+          rows: [{ cnt }],
+        } = await client.query(DRY_RUN_SQL, [state]);
+        updated = cnt;
+      } else {
+        const result = await client.query(BACKFILL_SQL, [state]);
+        updated = result.rowCount ?? 0;
+      }
+
+      const elapsed = (Date.now() - stateStart) / 1000;
+      results.push({
+        state,
+        total,
+        updated,
+        elapsedSec: parseFloat(elapsed.toFixed(1)),
+      });
+      grandTotalUpdated += updated;
+
+      if (updated > 0) {
+        const pct = ((updated / total) * 100).toFixed(1);
+        console.log(
+          `  [${ts()}] ${state}: ${updated.toLocaleString()} / ${total.toLocaleString()} ` +
+            `(${pct}%) ${config.dryRun ? "would be" : ""} updated (${elapsed.toFixed(1)}s)`
+        );
+      } else {
+        console.log(
+          `  [${ts()}] ${state}: ${total.toLocaleString()} charges, none matched (${elapsed.toFixed(1)}s)`
+        );
+      }
+
+      client.release();
+    } catch (err) {
+      client.release(true);
+      console.error(
+        `  [${ts()}] ${state}: ERROR — ${err instanceof Error ? err.message : err}`
+      );
+    }
+  }
+
+  // Summary
+  const overallElapsed = ((Date.now() - overallStart) / 1000).toFixed(1);
+
+  console.log("\n── Summary ──\n");
+  console.log(`  Mode:            ${config.dryRun ? "DRY RUN" : "LIVE"}`);
+  console.log(`  Total updated:   ${grandTotalUpdated.toLocaleString()}`);
+  console.log(`  Duration:        ${overallElapsed}s`);
+
+  // Post-backfill distribution (live mode, all states)
+  if (!config.dryRun && !config.state) {
+    console.log("\n── Body Site Distribution ──\n");
+    const { rows: distRows } = await pgPool.query(
+      "SELECT body_site, COUNT(*)::int AS cnt FROM charges GROUP BY body_site ORDER BY cnt DESC"
+    );
+    for (const row of distRows) {
+      console.log(
+        `  ${row.body_site ?? "(null)"}: ${Number(row.cnt).toLocaleString()}`
+      );
+    }
+  }
+
+  // JSON summary
+  console.log("\n── JSON Summary ──\n");
+  console.log(
+    JSON.stringify(
+      {
+        mode: config.dryRun ? "dry_run" : "live",
+        totalUpdated: grandTotalUpdated,
+        durationSec: parseFloat(overallElapsed),
+        states: results,
+      },
+      null,
+      2
+    )
+  );
+
+  await pgPool.end();
+  console.log("\n  Done.");
+}
+
+main().catch((err) => {
+  console.error("FATAL:", err);
+  process.exit(1);
+});

--- a/scripts/migration-body-site.sql
+++ b/scripts/migration-body-site.sql
@@ -1,0 +1,81 @@
+-- Migration: Add body_site column to charges table
+-- Issue: https://github.com/achrispratt/clearcost/issues/51
+--
+-- Run each statement SEPARATELY in the Supabase SQL editor.
+-- CREATE INDEX CONCURRENTLY cannot run inside a transaction block.
+
+-- ============================================================================
+-- Statement 1: Add the column
+-- ============================================================================
+ALTER TABLE charges ADD COLUMN IF NOT EXISTS body_site text;
+
+-- ============================================================================
+-- Statement 2: Partial index (run separately — CONCURRENTLY requires it)
+-- ============================================================================
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_charges_body_site
+  ON charges (body_site) WHERE body_site IS NOT NULL;
+
+-- ============================================================================
+-- Statement 3: SQL body-site parser function
+-- Mirrors the TypeScript parseBodySite() in lib/cpt/parse-body-site.ts.
+-- Uses Postgres \m (start-of-word) and \M (end-of-word) boundaries.
+-- ============================================================================
+CREATE OR REPLACE FUNCTION parse_body_site(p_description text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT CASE
+    -- Generic exclusions: return null for multi-site descriptions
+    WHEN p_description IS NOT NULL AND upper(p_description) ~ '\mLOW(ER)?\s+EXTREMITY\s+JOINT\M'
+      THEN NULL
+    WHEN p_description IS NOT NULL AND upper(p_description) ~ '\mUPPER\s+EXTREMITY\s+JOINT\M'
+      THEN NULL
+    WHEN p_description IS NOT NULL AND upper(p_description) ~ '\mANY\s+JOINT\M'
+      THEN NULL
+
+    -- Joints (most specific first)
+    WHEN p_description IS NOT NULL AND upper(p_description) ~ '\mKNEE\M'
+      THEN 'knee'
+    WHEN p_description IS NOT NULL AND upper(p_description) ~ '\mHIP\M'
+      THEN 'hip'
+    WHEN p_description IS NOT NULL AND upper(p_description) ~ '\mANKLE\M'
+      THEN 'ankle'
+    WHEN p_description IS NOT NULL AND upper(p_description) ~ '\mSHOULDER\M'
+      THEN 'shoulder'
+    WHEN p_description IS NOT NULL AND upper(p_description) ~ '\mELBOW\M'
+      THEN 'elbow'
+    WHEN p_description IS NOT NULL AND upper(p_description) ~ '\mWRIST\M'
+      THEN 'wrist'
+    WHEN p_description IS NOT NULL AND upper(p_description) ~ '\mHAND\M'
+      THEN 'hand'
+    WHEN p_description IS NOT NULL AND (upper(p_description) ~ '\mFOOT\M' OR upper(p_description) ~ '\mFEET\M')
+      THEN 'foot'
+
+    -- Spine segments
+    WHEN p_description IS NOT NULL AND (upper(p_description) ~ '\mCERVICAL\M' OR upper(p_description) ~ '\mC[\s-]?SPINE\M')
+      THEN 'cervical_spine'
+    WHEN p_description IS NOT NULL AND (upper(p_description) ~ '\mTHORACIC\M' OR upper(p_description) ~ '\mT[\s-]?SPINE\M')
+      THEN 'thoracic_spine'
+    WHEN p_description IS NOT NULL AND (upper(p_description) ~ '\mLUMBAR\M' OR upper(p_description) ~ '\mL[\s-]?SPINE\M')
+      THEN 'lumbar_spine'
+    WHEN p_description IS NOT NULL AND (upper(p_description) ~ '\mSACRAL\M' OR upper(p_description) ~ '\mSACRUM\M')
+      THEN 'sacral_spine'
+
+    -- Torso/body regions
+    WHEN p_description IS NOT NULL AND upper(p_description) ~ '\mCHEST\M'
+      THEN 'chest'
+    WHEN p_description IS NOT NULL AND (upper(p_description) ~ '\mABDOMEN\M' OR upper(p_description) ~ '\mABDOMINAL\M')
+      THEN 'abdomen'
+    WHEN p_description IS NOT NULL AND upper(p_description) ~ '\mPELVI[SC]\M'
+      THEN 'pelvis'
+
+    -- Head/neck
+    WHEN p_description IS NOT NULL AND (upper(p_description) ~ '\mHEAD\M' OR upper(p_description) ~ '\mBRAIN\M' OR upper(p_description) ~ '\mCRANIAL\M')
+      THEN 'head'
+    WHEN p_description IS NOT NULL AND upper(p_description) ~ '\mNECK\M'
+      THEN 'neck'
+
+    ELSE NULL
+  END;
+$$;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -61,6 +61,7 @@ create table if not exists charges (
   icd text,            -- ICD-10 diagnosis/procedure code
   modifiers text,      -- Modifier codes (comma-separated if multiple)
   laterality text,     -- 'left', 'right', 'bilateral', or null (parsed from description/modifiers)
+  body_site text,      -- 'knee', 'hip', 'shoulder', etc., or null (parsed from description)
 
   -- Base prices (from hospital's published standard charges)
   gross_charge numeric(12, 2),     -- Chargemaster / list price
@@ -91,6 +92,7 @@ create index if not exists idx_charges_provider_hcpcs on charges (provider_id, h
 create index if not exists idx_charges_provider_ms_drg on charges (provider_id, ms_drg);
 create index if not exists idx_charges_description on charges using gin (to_tsvector('english', coalesce(description, '')));
 create index if not exists idx_charges_laterality on charges (laterality) where laterality is not null;
+create index if not exists idx_charges_body_site on charges (body_site) where body_site is not null;
 
 -- ============================================================================
 -- Laterality parser (SQL mirror of lib/cpt/parse-laterality.ts)
@@ -121,6 +123,64 @@ as $$
       then 'left'
     when p_description is not null and upper(p_description) ~ '\mRIGHT\M'
       then 'right'
+    else null
+  end;
+$$;
+
+-- ============================================================================
+-- Body-site parser (SQL mirror of lib/cpt/parse-body-site.ts)
+-- ============================================================================
+create or replace function parse_body_site(p_description text)
+returns text
+language sql
+immutable
+as $$
+  select case
+    -- Generic exclusions
+    when p_description is not null and upper(p_description) ~ '\mLOW(ER)?\s+EXTREMITY\s+JOINT\M'
+      then null
+    when p_description is not null and upper(p_description) ~ '\mUPPER\s+EXTREMITY\s+JOINT\M'
+      then null
+    when p_description is not null and upper(p_description) ~ '\mANY\s+JOINT\M'
+      then null
+    -- Joints
+    when p_description is not null and upper(p_description) ~ '\mKNEE\M'
+      then 'knee'
+    when p_description is not null and upper(p_description) ~ '\mHIP\M'
+      then 'hip'
+    when p_description is not null and upper(p_description) ~ '\mANKLE\M'
+      then 'ankle'
+    when p_description is not null and upper(p_description) ~ '\mSHOULDER\M'
+      then 'shoulder'
+    when p_description is not null and upper(p_description) ~ '\mELBOW\M'
+      then 'elbow'
+    when p_description is not null and upper(p_description) ~ '\mWRIST\M'
+      then 'wrist'
+    when p_description is not null and upper(p_description) ~ '\mHAND\M'
+      then 'hand'
+    when p_description is not null and (upper(p_description) ~ '\mFOOT\M' or upper(p_description) ~ '\mFEET\M')
+      then 'foot'
+    -- Spine segments
+    when p_description is not null and (upper(p_description) ~ '\mCERVICAL\M' or upper(p_description) ~ '\mC[\s-]?SPINE\M')
+      then 'cervical_spine'
+    when p_description is not null and (upper(p_description) ~ '\mTHORACIC\M' or upper(p_description) ~ '\mT[\s-]?SPINE\M')
+      then 'thoracic_spine'
+    when p_description is not null and (upper(p_description) ~ '\mLUMBAR\M' or upper(p_description) ~ '\mL[\s-]?SPINE\M')
+      then 'lumbar_spine'
+    when p_description is not null and (upper(p_description) ~ '\mSACRAL\M' or upper(p_description) ~ '\mSACRUM\M')
+      then 'sacral_spine'
+    -- Torso/body regions
+    when p_description is not null and upper(p_description) ~ '\mCHEST\M'
+      then 'chest'
+    when p_description is not null and (upper(p_description) ~ '\mABDOMEN\M' or upper(p_description) ~ '\mABDOMINAL\M')
+      then 'abdomen'
+    when p_description is not null and upper(p_description) ~ '\mPELVI[SC]\M'
+      then 'pelvis'
+    -- Head/neck
+    when p_description is not null and (upper(p_description) ~ '\mHEAD\M' or upper(p_description) ~ '\mBRAIN\M' or upper(p_description) ~ '\mCRANIAL\M')
+      then 'head'
+    when p_description is not null and upper(p_description) ~ '\mNECK\M'
+      then 'neck'
     else null
   end;
 $$;
@@ -197,7 +257,8 @@ create or replace function search_charges_nearby(
   p_radius_km double precision default 40,
   p_limit integer default 600,
   p_provider_limit integer default 300,
-  p_laterality text default null -- 'left', 'right', 'bilateral', or null (no filter)
+  p_laterality text default null, -- 'left', 'right', 'bilateral', or null (no filter)
+  p_body_site text default null  -- 'knee', 'hip', etc., or null (no filter)
 )
 returns table (
   id uuid,
@@ -216,6 +277,7 @@ returns table (
   setting text,
   billing_class text,
   laterality text,
+  body_site text,
   cpt text,
   hcpcs text,
   ms_drg text,
@@ -276,6 +338,7 @@ as $$
     c.setting,
     c.billing_class,
     c.laterality,
+    c.body_site,
     c.cpt,
     c.hcpcs,
     c.ms_drg,
@@ -299,6 +362,7 @@ as $$
       or (p_code_type = 'ms_drg' and c.ms_drg = any(p_codes))
     )
     and (p_laterality is null or c.laterality = p_laterality)
+    and (p_body_site is null or c.body_site = p_body_site)
   order by np.distance_km asc, c.cash_price asc nulls last
   limit greatest(coalesce(p_limit, 600), 1);
 $$;
@@ -333,6 +397,7 @@ returns table (
   setting text,
   billing_class text,
   laterality text,
+  body_site text,
   cpt text,
   hcpcs text,
   ms_drg text,
@@ -397,6 +462,7 @@ as $$
     c.setting,
     c.billing_class,
     c.laterality,
+    c.body_site,
     c.cpt,
     c.hcpcs,
     c.ms_drg,

--- a/types/index.ts
+++ b/types/index.ts
@@ -11,6 +11,26 @@ export type ConfidenceLevel = "high" | "low";
 // -- Laterality --
 export type Laterality = "left" | "right" | "bilateral";
 
+// -- Body site (parsed from charge description) --
+export type BodySite =
+  | "knee"
+  | "hip"
+  | "ankle"
+  | "shoulder"
+  | "elbow"
+  | "wrist"
+  | "hand"
+  | "foot"
+  | "cervical_spine"
+  | "thoracic_spine"
+  | "lumbar_spine"
+  | "sacral_spine"
+  | "chest"
+  | "abdomen"
+  | "pelvis"
+  | "head"
+  | "neck";
+
 // -- Care setting --
 export type ChargeSetting = "inpatient" | "outpatient" | "both";
 export type AdderEstimateSource = "facility" | "local_fallback";
@@ -50,6 +70,8 @@ export interface PricingPlan {
   baseCodeGroups: PricingCodeGroup[];
   adders: PlannedAdder[];
   proxyLabel?: string;
+  laterality?: Laterality;
+  bodySite?: BodySite;
 }
 
 export interface OptionalAdderEstimate {
@@ -94,6 +116,7 @@ export interface ChargeResult {
   setting?: ChargeSetting;
   billingClass?: string;
   laterality?: Laterality;
+  bodySite?: BodySite;
 
   // Billing codes (a charge may have codes in multiple systems)
   cpt?: string;
@@ -190,6 +213,8 @@ export interface TranslationResponse {
   confidence: ConfidenceLevel;
   queryType?: QueryType;
   pricingPlan?: PricingPlan;
+  laterality?: Laterality;
+  bodySite?: BodySite;
   nextQuestion?: ClarificationQuestion;
   conversationComplete?: boolean;
 }


### PR DESCRIPTION
## Summary

- **Adds `body_site` column** to charges table with TS parser, SQL function, migration, backfill script, and import pipeline integration
- **Connects both `laterality` AND `bodySite`** end-to-end through guided search → pricing plan → lookup chain → Supabase RPC filtering
- **Updates Claude system prompts** to extract and include laterality/bodySite in every relevant response, with explicit imaging triage rules

## Why

CPT 73721 = "MRI, any joint of lower extremity" covers knee, hip, AND ankle under one code. Hospitals list separate charges with different prices for each body site. Without body_site filtering, a "knee MRI" search returns all lower extremity joints. Laterality plumbing already existed but was never connected — the guided search never asked, and `lookupWithPricingPlan()` never passed it to the RPC.

## Files changed (13)

| File | Change |
|------|--------|
| `types/index.ts` | `BodySite` type; laterality/bodySite on PricingPlan, TranslationResponse, ChargeResult |
| `lib/cpt/parse-body-site.ts` | **New** — body-site parser (regex, most-specific-first) |
| `lib/cpt/body-site-laterality-constants.ts` | **New** — shared validation constants + extraction helpers |
| `scripts/migration-body-site.sql` | **New** — DDL + index + SQL parser function |
| `scripts/backfill-body-site.ts` | **New** — state-by-state backfill script |
| `lib/data/import-trilliant.ts` | body_site in import pipeline |
| `supabase/schema.sql` | Column, index, function, both RPCs updated with `p_body_site` |
| `lib/cpt/prompts.ts` | Both system prompts updated for laterality + bodySite |
| `lib/cpt/translate.ts` | Extract laterality/bodySite from Claude responses |
| `lib/cpt/pricing-plan.ts` | Normalize and thread laterality/bodySite |
| `lib/cpt/lookup.ts` | Thread through full lookup chain to RPC |
| `lib/cpt/cache.ts` | laterality/bodySite in cache payload |
| `app/api/search/route.ts` | Pass through to buildPricingPlan + cache |

## Deploy steps (schema-first, then code)

Run these **before merging** — additive schema changes are safe to deploy ahead of code.

1. Run `migration-body-site.sql` in Supabase SQL editor (3 statements, run separately)
2. Deploy updated RPC functions (copy `search_charges_nearby` + `search_charges_by_description` from `supabase/schema.sql` into SQL editor)
3. Merge this PR (Vercel auto-deploys the code that uses the new column/param)
4. Run backfill: `npx tsx --env-file=.env.local scripts/backfill-body-site.ts --dry-run` then live

## Test plan

- [ ] Parser unit check: `parseBodySite('MR KNEE NO IV CONTRAST')` → `knee`, `parseBodySite('MR LOW EXTREMITY JOINT')` → `null`
- [ ] Backfill dry-run shows non-zero counts for imaging-heavy states
- [ ] RPC test: `SELECT body_site, COUNT(*) FROM charges WHERE cpt = '73721' AND body_site IS NOT NULL GROUP BY body_site`
- [ ] End-to-end: "knee MRI" → asks laterality → results filter to knee only
- [ ] Fallback: "lower extremity MRI" without body site → shows ALL joints (null = no filter)
- [ ] `npm run lint` + type check pass ✅

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)