### PR TITLE
Consolidate duplicated utilities and optimize SQL parse functions

### DIFF
--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -15,6 +15,7 @@ import {
   getTranslationCacheKey,
   setCachedTranslation,
 } from "@/lib/cpt/cache";
+import { normalizeCodeType } from "@/lib/cpt/body-site-laterality-constants";
 import { handleApiError } from "@/lib/api-helpers";
 import type { BillingCodeType, CPTCode, PricingPlan } from "@/types";
 
@@ -34,11 +35,6 @@ async function lookupWithAutoExpand(
 }
 
 type CacheStatus = "hit" | "miss" | "skip";
-
-function normalizeCodeType(value: unknown): BillingCodeType {
-  if (value === "hcpcs" || value === "ms_drg") return value;
-  return "cpt";
-}
 
 function normalizeCodeGroups(
   value: unknown

--- a/lib/cpt/body-site-laterality-constants.ts
+++ b/lib/cpt/body-site-laterality-constants.ts
@@ -5,7 +5,16 @@
  * (normalizing pricing plan input). Single source of truth for valid values.
  */
 
-import type { BodySite, Laterality } from "@/types";
+import type { BillingCodeType, BodySite, Laterality } from "@/types";
+
+export function normalizeCodeType(value: unknown): BillingCodeType {
+  if (value === "hcpcs" || value === "ms_drg") return value;
+  return "cpt";
+}
+
+export function normalizeCodeValue(code: string): string {
+  return code.trim().toUpperCase();
+}
 
 export const VALID_LATERALITIES: ReadonlySet<Laterality> = new Set([
   "left",
@@ -33,16 +42,18 @@ export const VALID_BODY_SITES: ReadonlySet<BodySite> = new Set([
   "neck",
 ]);
 
-export function extractLaterality(value: unknown): Laterality | undefined {
+function extractFromSet<T extends string>(
+  set: ReadonlySet<T>,
+  value: unknown
+): T | undefined {
   if (typeof value !== "string") return undefined;
-  return VALID_LATERALITIES.has(value as Laterality)
-    ? (value as Laterality)
-    : undefined;
+  return set.has(value as T) ? (value as T) : undefined;
+}
+
+export function extractLaterality(value: unknown): Laterality | undefined {
+  return extractFromSet(VALID_LATERALITIES, value);
 }
 
 export function extractBodySite(value: unknown): BodySite | undefined {
-  if (typeof value !== "string") return undefined;
-  return VALID_BODY_SITES.has(value as BodySite)
-    ? (value as BodySite)
-    : undefined;
+  return extractFromSet(VALID_BODY_SITES, value);
 }

--- a/lib/cpt/lookup.ts
+++ b/lib/cpt/lookup.ts
@@ -13,6 +13,11 @@ import type {
   PricingPlan,
 } from "@/types";
 
+interface LookupFilters {
+  laterality?: Laterality;
+  bodySite?: BodySite;
+}
+
 interface LookupParams {
   codes: string[];
   codeType?: BillingCodeType;
@@ -461,8 +466,7 @@ async function queryCodeGroupsAtRadius({
   lat,
   lng,
   radiusMiles,
-  laterality,
-  bodySite,
+  filters,
   diagnostics,
   stage,
 }: {
@@ -470,8 +474,7 @@ async function queryCodeGroupsAtRadius({
   lat: number;
   lng: number;
   radiusMiles: number;
-  laterality?: Laterality;
-  bodySite?: BodySite;
+  filters?: LookupFilters;
   diagnostics?: LookupDiagnostics;
   stage: string;
 }): Promise<ChargeResult[]> {
@@ -480,7 +483,7 @@ async function queryCodeGroupsAtRadius({
   const responses = await Promise.all(
     codeGroups.map(({ codeType, codes }) =>
       lookupCharges(
-        { codes, codeType, lat, lng, radiusMiles, laterality, bodySite },
+        { codes, codeType, lat, lng, radiusMiles, ...filters },
         { diagnostics, stage }
       )
     )
@@ -494,8 +497,7 @@ async function queryCodeGroupsWithFallback({
   lat,
   lng,
   radiusMiles = 25,
-  laterality,
-  bodySite,
+  filters,
   descriptionFallback,
   diagnostics,
   stage,
@@ -504,8 +506,7 @@ async function queryCodeGroupsWithFallback({
   lat: number;
   lng: number;
   radiusMiles?: number;
-  laterality?: Laterality;
-  bodySite?: BodySite;
+  filters?: LookupFilters;
   descriptionFallback?: string;
   diagnostics?: LookupDiagnostics;
   stage: string;
@@ -542,8 +543,7 @@ async function queryCodeGroupsWithFallback({
     lat,
     lng,
     radiusMiles,
-    laterality,
-    bodySite,
+    filters,
     diagnostics,
     stage: `${stage}:initial`,
   });
@@ -560,8 +560,7 @@ async function queryCodeGroupsWithFallback({
     lat,
     lng,
     radiusMiles: expandedRadius,
-    laterality,
-    bodySite,
+    filters,
     diagnostics,
     stage: `${stage}:expanded`,
   });
@@ -807,13 +806,16 @@ export async function lookupWithPricingPlan({
   diagnostics,
 }: LookupWithPlanParams): Promise<ChargeResult[]> {
   // Thread laterality/bodySite to base results only — adders are separate procedures
+  const baseFilters: LookupFilters = {
+    laterality: pricingPlan.laterality,
+    bodySite: pricingPlan.bodySite,
+  };
   const baseResults = await queryCodeGroupsWithFallback({
     codeGroups: pricingPlan.baseCodeGroups,
     lat,
     lng,
     radiusMiles,
-    laterality: pricingPlan.laterality,
-    bodySite: pricingPlan.bodySite,
+    filters: baseFilters,
     descriptionFallback,
     diagnostics,
     stage: "base",

--- a/lib/cpt/pricing-plan.ts
+++ b/lib/cpt/pricing-plan.ts
@@ -1,6 +1,8 @@
 import {
   extractLaterality,
   extractBodySite,
+  normalizeCodeType,
+  normalizeCodeValue,
 } from "./body-site-laterality-constants";
 import type {
   BodySite,
@@ -97,15 +99,6 @@ export interface BuildPricingPlanParams {
   bodySite?: BodySite;
 }
 
-function normalizeCodeType(value: unknown): BillingCodeType {
-  if (value === "hcpcs" || value === "ms_drg") return value;
-  return "cpt";
-}
-
-function normalizeCode(code: string): string {
-  return code.trim().toUpperCase();
-}
-
 function normalizeCodeGroups(value: unknown): PricingCodeGroup[] {
   if (!Array.isArray(value)) return [];
 
@@ -123,7 +116,7 @@ function normalizeCodeGroups(value: unknown): PricingCodeGroup[] {
               (code): code is string =>
                 typeof code === "string" && code.trim().length > 0
             )
-            .map((code) => normalizeCode(code))
+            .map((code) => normalizeCodeValue(code))
         : [];
 
       return {
@@ -186,7 +179,7 @@ function dedupeCodeGroups(codeGroups: PricingCodeGroup[]): PricingCodeGroup[] {
     const key = group.codeType;
     const existing = merged.get(key) || new Set<string>();
     for (const code of group.codes) {
-      existing.add(normalizeCode(code));
+      existing.add(normalizeCodeValue(code));
     }
     merged.set(key, existing);
     if (group.label && !labels.has(key)) labels.set(key, group.label);
@@ -206,7 +199,7 @@ function codesToGroups(codes: CPTCode[] = []): PricingCodeGroup[] {
 
   for (const code of codes) {
     const codeType = normalizeCodeType(code.codeType);
-    const normalized = normalizeCode(code.code);
+    const normalized = normalizeCodeValue(code.code);
     const existing = grouped.get(codeType) || new Set<string>();
     existing.add(normalized);
     grouped.set(codeType, existing);

--- a/lib/cpt/translate.ts
+++ b/lib/cpt/translate.ts
@@ -10,6 +10,8 @@ import { normalizePricingPlanInput } from "./pricing-plan";
 import {
   extractLaterality,
   extractBodySite,
+  normalizeCodeType,
+  normalizeCodeValue,
 } from "./body-site-laterality-constants";
 import type {
   BodySite,
@@ -84,15 +86,6 @@ type RawCode = {
   description: string;
   category: string;
 };
-
-function normalizeCodeType(value: unknown): BillingCodeType {
-  if (value === "hcpcs" || value === "ms_drg") return value;
-  return "cpt";
-}
-
-function normalizeCodeValue(code: string): string {
-  return code.trim().toUpperCase();
-}
 
 function detectContrastPreference(
   query: string

--- a/scripts/backfill-body-site.ts
+++ b/scripts/backfill-body-site.ts
@@ -2,9 +2,6 @@
  * Backfill the body_site column on existing charges using the SQL
  * parse_body_site() function (must be deployed first via migration-body-site.sql).
  *
- * All parsing runs inside Postgres — Node.js only manages state-by-state
- * control flow and progress logging.
- *
  * Issue: https://github.com/achrispratt/clearcost/issues/51
  *
  * Prerequisites:
@@ -16,265 +13,45 @@
  *   npx tsx --env-file=.env.local scripts/backfill-body-site.ts
  */
 
-import { Pool as PgPool } from "pg";
-
-// ---------------------------------------------------------------------------
-// Config
-// ---------------------------------------------------------------------------
-
-function parseArgs(): {
-  dryRun: boolean;
-  state: string | null;
-  skipStates: string[];
-} {
-  const args = process.argv.slice(2);
-  let dryRun = false;
-  let state: string | null = null;
-  const skipStates: string[] = [];
-
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--dry-run") {
-      dryRun = true;
-    } else if (args[i] === "--state" && args[i + 1]) {
-      state = args[i + 1].toUpperCase();
-      i++;
-    } else if (args[i] === "--skip-states" && args[i + 1]) {
-      skipStates.push(
-        ...args[i + 1].split(",").map((s) => s.trim().toUpperCase())
-      );
-      i++;
-    }
-  }
-  return { dryRun, state, skipStates };
-}
-
-function ts(): string {
-  return new Date().toISOString().slice(11, 19);
-}
-
-// ---------------------------------------------------------------------------
-// SQL
-// ---------------------------------------------------------------------------
-
-// Backfill: set body_site using the SQL function, only for un-processed rows
-// where description is non-null and parse_body_site returns non-null.
-const BACKFILL_SQL = `
-  UPDATE charges c
-  SET body_site = parse_body_site(c.description)
-  FROM providers p
-  WHERE c.provider_id = p.id
-    AND p.state = $1
-    AND c.body_site IS NULL
-    AND c.description IS NOT NULL
-    AND parse_body_site(c.description) IS NOT NULL
-`;
-
-// Dry-run: count how many rows would be updated per state.
-const DRY_RUN_SQL = `
-  SELECT COUNT(*)::int AS cnt
-  FROM charges c
-  JOIN providers p ON c.provider_id = p.id
-  WHERE p.state = $1
-    AND c.body_site IS NULL
-    AND c.description IS NOT NULL
-    AND parse_body_site(c.description) IS NOT NULL
-`;
-
-// Count total charges in state (for context).
-const STATE_COUNT_SQL = `
-  SELECT COUNT(*)::int AS cnt
-  FROM charges c
-  JOIN providers p ON c.provider_id = p.id
-  WHERE p.state = $1
-`;
-
-// ---------------------------------------------------------------------------
-// Main
-// ---------------------------------------------------------------------------
-
-interface StateResult {
-  state: string;
-  total: number;
-  updated: number;
-  elapsedSec: number;
-}
+import { runBackfill } from "./lib/run-backfill";
 
 async function main() {
-  const config = parseArgs();
-
-  console.log("=== ClearCost Body Site Backfill ===\n");
-  console.log(
-    `  Mode: ${config.dryRun ? "DRY RUN (no data will be modified)" : "LIVE — body_site will be set"}`
-  );
-  if (config.state) console.log(`  State filter: ${config.state}`);
-  if (config.skipStates.length > 0)
-    console.log(`  Skipping states: ${config.skipStates.join(", ")}`);
-  console.log();
-
-  // Connect via Supabase pooler (port 6543)
-  const dbUrl = process.env.SUPABASE_DB_URL;
-  if (!dbUrl) {
-    console.error("ERROR: SUPABASE_DB_URL not set. Use --env-file=.env.local");
-    process.exit(1);
-  }
-  const poolerUrl = dbUrl.replace(/:5432\//, ":6543/");
-  const pgPool = new PgPool({
-    connectionString: poolerUrl,
-    ssl: { rejectUnauthorized: false },
-    max: 2,
-    idleTimeoutMillis: 30000,
-    connectionTimeoutMillis: 30000,
-    keepAlive: true,
-    keepAliveInitialDelayMillis: 10000,
-  });
-  pgPool.on("error", (err) => {
-    console.warn(`  Pool background error (non-fatal): ${err.message}`);
-  });
-  await pgPool.query("SELECT 1");
-  console.log("  Postgres pool connected\n");
-
-  // Verify parse_body_site() function exists
-  try {
-    await pgPool.query("SELECT parse_body_site('MR KNEE NO IV CONTRAST')");
-  } catch {
-    console.error(
+  await runBackfill({
+    label: "Body Site",
+    column: "body_site",
+    backfillSql: `
+      UPDATE charges c
+      SET body_site = computed.site
+      FROM (
+        SELECT c2.id, parse_body_site(c2.description) AS site
+        FROM charges c2
+        JOIN providers p ON c2.provider_id = p.id
+        WHERE p.state = $1
+          AND c2.body_site IS NULL
+          AND c2.description IS NOT NULL
+      ) computed
+      WHERE c.id = computed.id
+        AND computed.site IS NOT NULL
+    `,
+    dryRunSql: `
+      SELECT COUNT(*)::int AS cnt
+      FROM (
+        SELECT parse_body_site(c.description) AS site
+        FROM charges c
+        JOIN providers p ON c.provider_id = p.id
+        WHERE p.state = $1
+          AND c.body_site IS NULL
+          AND c.description IS NOT NULL
+      ) computed
+      WHERE computed.site IS NOT NULL
+    `,
+    smokeTestSql: "SELECT parse_body_site('MR KNEE NO IV CONTRAST')",
+    smokeTestError:
       "ERROR: parse_body_site() function not found.\n" +
-        "Run migration-body-site.sql in Supabase SQL editor first."
-    );
-    process.exit(1);
-  }
-
-  // Get state list
-  let states: string[];
-  if (config.state) {
-    states = [config.state];
-  } else {
-    const { rows } = await pgPool.query(
-      "SELECT DISTINCT state FROM providers WHERE state IS NOT NULL ORDER BY state"
-    );
-    states = rows.map((r: { state: string }) => r.state);
-  }
-
-  // Process each state
-  const results: StateResult[] = [];
-  let grandTotalUpdated = 0;
-  const overallStart = Date.now();
-
-  for (const state of states) {
-    if (config.skipStates.includes(state)) {
-      console.log(`  [${ts()}] ${state}: skipping`);
-      continue;
-    }
-
-    // Health check
-    try {
-      await pgPool.query("SELECT 1");
-    } catch {
-      console.warn(
-        `  [${ts()}] ${state}: Postgres health check failed, waiting 10s...`
-      );
-      await new Promise((r) => setTimeout(r, 10000));
-      try {
-        await pgPool.query("SELECT 1");
-        console.log(`  [${ts()}] ${state}: reconnected after retry`);
-      } catch (retryErr) {
-        console.error(
-          `  [${ts()}] ${state}: SKIPPING — Postgres unreachable (${retryErr instanceof Error ? retryErr.message : retryErr})`
-        );
-        continue;
-      }
-    }
-
-    const stateStart = Date.now();
-    const client = await pgPool.connect();
-
-    try {
-      await client.query("SET statement_timeout = 0");
-
-      // Count total charges in state
-      const {
-        rows: [{ cnt: total }],
-      } = await client.query(STATE_COUNT_SQL, [state]);
-
-      let updated: number;
-      if (config.dryRun) {
-        const {
-          rows: [{ cnt }],
-        } = await client.query(DRY_RUN_SQL, [state]);
-        updated = cnt;
-      } else {
-        const result = await client.query(BACKFILL_SQL, [state]);
-        updated = result.rowCount ?? 0;
-      }
-
-      const elapsed = (Date.now() - stateStart) / 1000;
-      results.push({
-        state,
-        total,
-        updated,
-        elapsedSec: parseFloat(elapsed.toFixed(1)),
-      });
-      grandTotalUpdated += updated;
-
-      if (updated > 0) {
-        const pct = ((updated / total) * 100).toFixed(1);
-        console.log(
-          `  [${ts()}] ${state}: ${updated.toLocaleString()} / ${total.toLocaleString()} ` +
-            `(${pct}%) ${config.dryRun ? "would be" : ""} updated (${elapsed.toFixed(1)}s)`
-        );
-      } else {
-        console.log(
-          `  [${ts()}] ${state}: ${total.toLocaleString()} charges, none matched (${elapsed.toFixed(1)}s)`
-        );
-      }
-
-      client.release();
-    } catch (err) {
-      client.release(true);
-      console.error(
-        `  [${ts()}] ${state}: ERROR — ${err instanceof Error ? err.message : err}`
-      );
-    }
-  }
-
-  // Summary
-  const overallElapsed = ((Date.now() - overallStart) / 1000).toFixed(1);
-
-  console.log("\n── Summary ──\n");
-  console.log(`  Mode:            ${config.dryRun ? "DRY RUN" : "LIVE"}`);
-  console.log(`  Total updated:   ${grandTotalUpdated.toLocaleString()}`);
-  console.log(`  Duration:        ${overallElapsed}s`);
-
-  // Post-backfill distribution (live mode, all states)
-  if (!config.dryRun && !config.state) {
-    console.log("\n── Body Site Distribution ──\n");
-    const { rows: distRows } = await pgPool.query(
-      "SELECT body_site, COUNT(*)::int AS cnt FROM charges GROUP BY body_site ORDER BY cnt DESC"
-    );
-    for (const row of distRows) {
-      console.log(
-        `  ${row.body_site ?? "(null)"}: ${Number(row.cnt).toLocaleString()}`
-      );
-    }
-  }
-
-  // JSON summary
-  console.log("\n── JSON Summary ──\n");
-  console.log(
-    JSON.stringify(
-      {
-        mode: config.dryRun ? "dry_run" : "live",
-        totalUpdated: grandTotalUpdated,
-        durationSec: parseFloat(overallElapsed),
-        states: results,
-      },
-      null,
-      2
-    )
-  );
-
-  await pgPool.end();
-  console.log("\n  Done.");
+      "Run migration-body-site.sql in Supabase SQL editor first.",
+    distributionSql:
+      "SELECT body_site, COUNT(*)::int AS cnt FROM charges GROUP BY body_site ORDER BY cnt DESC",
+  });
 }
 
 main().catch((err) => {

--- a/scripts/backfill-laterality.ts
+++ b/scripts/backfill-laterality.ts
@@ -2,9 +2,6 @@
  * Backfill the laterality column on existing charges using the SQL
  * parse_laterality() function (must be deployed first via migration-laterality.sql).
  *
- * All parsing runs inside Postgres — Node.js only manages state-by-state
- * control flow and progress logging.
- *
  * Issue: https://github.com/achrispratt/clearcost/issues/48
  *
  * Prerequisites:
@@ -16,266 +13,45 @@
  *   npx tsx --env-file=.env.local scripts/backfill-laterality.ts
  */
 
-import { Pool as PgPool } from "pg";
-
-// ---------------------------------------------------------------------------
-// Config
-// ---------------------------------------------------------------------------
-
-function parseArgs(): {
-  dryRun: boolean;
-  state: string | null;
-  skipStates: string[];
-} {
-  const args = process.argv.slice(2);
-  let dryRun = false;
-  let state: string | null = null;
-  const skipStates: string[] = [];
-
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--dry-run") {
-      dryRun = true;
-    } else if (args[i] === "--state" && args[i + 1]) {
-      state = args[i + 1].toUpperCase();
-      i++;
-    } else if (args[i] === "--skip-states" && args[i + 1]) {
-      skipStates.push(
-        ...args[i + 1].split(",").map((s) => s.trim().toUpperCase())
-      );
-      i++;
-    }
-  }
-  return { dryRun, state, skipStates };
-}
-
-function ts(): string {
-  return new Date().toISOString().slice(11, 19);
-}
-
-// ---------------------------------------------------------------------------
-// SQL
-// ---------------------------------------------------------------------------
-
-// Backfill: set laterality using the SQL function, only for un-processed rows
-// where at least one source field (description or modifiers) is non-null.
-// The subquery filter ensures we only UPDATE rows where parse_laterality returns non-null.
-const BACKFILL_SQL = `
-  UPDATE charges c
-  SET laterality = parse_laterality(c.description, c.modifiers)
-  FROM providers p
-  WHERE c.provider_id = p.id
-    AND p.state = $1
-    AND c.laterality IS NULL
-    AND (c.description IS NOT NULL OR c.modifiers IS NOT NULL)
-    AND parse_laterality(c.description, c.modifiers) IS NOT NULL
-`;
-
-// Dry-run: count how many rows would be updated per state.
-const DRY_RUN_SQL = `
-  SELECT COUNT(*)::int AS cnt
-  FROM charges c
-  JOIN providers p ON c.provider_id = p.id
-  WHERE p.state = $1
-    AND c.laterality IS NULL
-    AND (c.description IS NOT NULL OR c.modifiers IS NOT NULL)
-    AND parse_laterality(c.description, c.modifiers) IS NOT NULL
-`;
-
-// Count total charges in state (for context).
-const STATE_COUNT_SQL = `
-  SELECT COUNT(*)::int AS cnt
-  FROM charges c
-  JOIN providers p ON c.provider_id = p.id
-  WHERE p.state = $1
-`;
-
-// ---------------------------------------------------------------------------
-// Main
-// ---------------------------------------------------------------------------
-
-interface StateResult {
-  state: string;
-  total: number;
-  updated: number;
-  elapsedSec: number;
-}
+import { runBackfill } from "./lib/run-backfill";
 
 async function main() {
-  const config = parseArgs();
-
-  console.log("=== ClearCost Laterality Backfill ===\n");
-  console.log(
-    `  Mode: ${config.dryRun ? "DRY RUN (no data will be modified)" : "LIVE — laterality will be set"}`
-  );
-  if (config.state) console.log(`  State filter: ${config.state}`);
-  if (config.skipStates.length > 0)
-    console.log(`  Skipping states: ${config.skipStates.join(", ")}`);
-  console.log();
-
-  // Connect via Supabase pooler (port 6543)
-  const dbUrl = process.env.SUPABASE_DB_URL;
-  if (!dbUrl) {
-    console.error("ERROR: SUPABASE_DB_URL not set. Use --env-file=.env.local");
-    process.exit(1);
-  }
-  const poolerUrl = dbUrl.replace(/:5432\//, ":6543/");
-  const pgPool = new PgPool({
-    connectionString: poolerUrl,
-    ssl: { rejectUnauthorized: false },
-    max: 2,
-    idleTimeoutMillis: 30000,
-    connectionTimeoutMillis: 30000,
-    keepAlive: true,
-    keepAliveInitialDelayMillis: 10000,
-  });
-  pgPool.on("error", (err) => {
-    console.warn(`  Pool background error (non-fatal): ${err.message}`);
-  });
-  await pgPool.query("SELECT 1");
-  console.log("  Postgres pool connected\n");
-
-  // Verify parse_laterality() function exists
-  try {
-    await pgPool.query("SELECT parse_laterality('MRI KNEE RT', 'RT')");
-  } catch {
-    console.error(
+  await runBackfill({
+    label: "Laterality",
+    column: "laterality",
+    backfillSql: `
+      UPDATE charges c
+      SET laterality = computed.lat
+      FROM (
+        SELECT c2.id, parse_laterality(c2.description, c2.modifiers) AS lat
+        FROM charges c2
+        JOIN providers p ON c2.provider_id = p.id
+        WHERE p.state = $1
+          AND c2.laterality IS NULL
+          AND (c2.description IS NOT NULL OR c2.modifiers IS NOT NULL)
+      ) computed
+      WHERE c.id = computed.id
+        AND computed.lat IS NOT NULL
+    `,
+    dryRunSql: `
+      SELECT COUNT(*)::int AS cnt
+      FROM (
+        SELECT parse_laterality(c.description, c.modifiers) AS lat
+        FROM charges c
+        JOIN providers p ON c.provider_id = p.id
+        WHERE p.state = $1
+          AND c.laterality IS NULL
+          AND (c.description IS NOT NULL OR c.modifiers IS NOT NULL)
+      ) computed
+      WHERE computed.lat IS NOT NULL
+    `,
+    smokeTestSql: "SELECT parse_laterality('MRI KNEE RT', 'RT')",
+    smokeTestError:
       "ERROR: parse_laterality() function not found.\n" +
-        "Run migration-laterality.sql in Supabase SQL editor first."
-    );
-    process.exit(1);
-  }
-
-  // Get state list
-  let states: string[];
-  if (config.state) {
-    states = [config.state];
-  } else {
-    const { rows } = await pgPool.query(
-      "SELECT DISTINCT state FROM providers WHERE state IS NOT NULL ORDER BY state"
-    );
-    states = rows.map((r: { state: string }) => r.state);
-  }
-
-  // Process each state
-  const results: StateResult[] = [];
-  let grandTotalUpdated = 0;
-  const overallStart = Date.now();
-
-  for (const state of states) {
-    if (config.skipStates.includes(state)) {
-      console.log(`  [${ts()}] ${state}: skipping`);
-      continue;
-    }
-
-    // Health check
-    try {
-      await pgPool.query("SELECT 1");
-    } catch {
-      console.warn(
-        `  [${ts()}] ${state}: Postgres health check failed, waiting 10s...`
-      );
-      await new Promise((r) => setTimeout(r, 10000));
-      try {
-        await pgPool.query("SELECT 1");
-        console.log(`  [${ts()}] ${state}: reconnected after retry`);
-      } catch (retryErr) {
-        console.error(
-          `  [${ts()}] ${state}: SKIPPING — Postgres unreachable (${retryErr instanceof Error ? retryErr.message : retryErr})`
-        );
-        continue;
-      }
-    }
-
-    const stateStart = Date.now();
-    const client = await pgPool.connect();
-
-    try {
-      await client.query("SET statement_timeout = 0");
-
-      // Count total charges in state
-      const {
-        rows: [{ cnt: total }],
-      } = await client.query(STATE_COUNT_SQL, [state]);
-
-      let updated: number;
-      if (config.dryRun) {
-        const {
-          rows: [{ cnt }],
-        } = await client.query(DRY_RUN_SQL, [state]);
-        updated = cnt;
-      } else {
-        const result = await client.query(BACKFILL_SQL, [state]);
-        updated = result.rowCount ?? 0;
-      }
-
-      const elapsed = (Date.now() - stateStart) / 1000;
-      results.push({
-        state,
-        total,
-        updated,
-        elapsedSec: parseFloat(elapsed.toFixed(1)),
-      });
-      grandTotalUpdated += updated;
-
-      if (updated > 0) {
-        const pct = ((updated / total) * 100).toFixed(1);
-        console.log(
-          `  [${ts()}] ${state}: ${updated.toLocaleString()} / ${total.toLocaleString()} ` +
-            `(${pct}%) ${config.dryRun ? "would be" : ""} updated (${elapsed.toFixed(1)}s)`
-        );
-      } else {
-        console.log(
-          `  [${ts()}] ${state}: ${total.toLocaleString()} charges, none matched (${elapsed.toFixed(1)}s)`
-        );
-      }
-
-      client.release();
-    } catch (err) {
-      client.release(true);
-      console.error(
-        `  [${ts()}] ${state}: ERROR — ${err instanceof Error ? err.message : err}`
-      );
-    }
-  }
-
-  // Summary
-  const overallElapsed = ((Date.now() - overallStart) / 1000).toFixed(1);
-
-  console.log("\n── Summary ──\n");
-  console.log(`  Mode:            ${config.dryRun ? "DRY RUN" : "LIVE"}`);
-  console.log(`  Total updated:   ${grandTotalUpdated.toLocaleString()}`);
-  console.log(`  Duration:        ${overallElapsed}s`);
-
-  // Post-backfill distribution (live mode, all states)
-  if (!config.dryRun && !config.state) {
-    console.log("\n── Laterality Distribution ──\n");
-    const { rows: distRows } = await pgPool.query(
-      "SELECT laterality, COUNT(*)::int AS cnt FROM charges GROUP BY laterality ORDER BY cnt DESC"
-    );
-    for (const row of distRows) {
-      console.log(
-        `  ${row.laterality ?? "(null)"}: ${Number(row.cnt).toLocaleString()}`
-      );
-    }
-  }
-
-  // JSON summary
-  console.log("\n── JSON Summary ──\n");
-  console.log(
-    JSON.stringify(
-      {
-        mode: config.dryRun ? "dry_run" : "live",
-        totalUpdated: grandTotalUpdated,
-        durationSec: parseFloat(overallElapsed),
-        states: results,
-      },
-      null,
-      2
-    )
-  );
-
-  await pgPool.end();
-  console.log("\n  Done.");
+      "Run migration-laterality.sql in Supabase SQL editor first.",
+    distributionSql:
+      "SELECT laterality, COUNT(*)::int AS cnt FROM charges GROUP BY laterality ORDER BY cnt DESC",
+  });
 }
 
 main().catch((err) => {

--- a/scripts/lib/run-backfill.ts
+++ b/scripts/lib/run-backfill.ts
@@ -1,0 +1,254 @@
+/**
+ * Shared backfill runner for column-level backfills.
+ *
+ * Handles Postgres pool management, state-by-state processing, progress
+ * logging, dry-run mode, and post-backfill distribution reporting.
+ *
+ * Each backfill script provides a config object specifying the column,
+ * SQL statements, and smoke-test query. The runner does everything else.
+ */
+
+import { Pool as PgPool } from "pg";
+
+// ---------------------------------------------------------------------------
+// Config interface
+// ---------------------------------------------------------------------------
+
+export interface BackfillConfig {
+  /** Display name for logging (e.g., "Laterality", "Body Site") */
+  label: string;
+  /** Column being backfilled */
+  column: string;
+  /**
+   * UPDATE statement that computes and sets the column value.
+   * Uses a CTE to call the parse function once per row.
+   * $1 = state code.
+   */
+  backfillSql: string;
+  /**
+   * COUNT query for dry-run mode. Should use a CTE to call the parse
+   * function once per row. $1 = state code.
+   */
+  dryRunSql: string;
+  /** Smoke-test SQL to verify the parse function exists (no params). */
+  smokeTestSql: string;
+  /** Error message if the smoke test fails. */
+  smokeTestError: string;
+  /** Distribution query for post-backfill summary (no params). */
+  distributionSql: string;
+}
+
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+
+function parseArgs(): {
+  dryRun: boolean;
+  state: string | null;
+  skipStates: string[];
+} {
+  const args = process.argv.slice(2);
+  let dryRun = false;
+  let state: string | null = null;
+  const skipStates: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--dry-run") {
+      dryRun = true;
+    } else if (args[i] === "--state" && args[i + 1]) {
+      state = args[i + 1].toUpperCase();
+      i++;
+    } else if (args[i] === "--skip-states" && args[i + 1]) {
+      skipStates.push(
+        ...args[i + 1].split(",").map((s) => s.trim().toUpperCase())
+      );
+      i++;
+    }
+  }
+  return { dryRun, state, skipStates };
+}
+
+function ts(): string {
+  return new Date().toISOString().slice(11, 19);
+}
+
+const STATE_COUNT_SQL = `
+  SELECT COUNT(*)::int AS cnt
+  FROM charges c
+  JOIN providers p ON c.provider_id = p.id
+  WHERE p.state = $1
+`;
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+interface StateResult {
+  state: string;
+  total: number;
+  updated: number;
+  elapsedSec: number;
+}
+
+export async function runBackfill(config: BackfillConfig): Promise<void> {
+  const cliArgs = parseArgs();
+
+  console.log(`=== ClearCost ${config.label} Backfill ===\n`);
+  console.log(
+    `  Mode: ${cliArgs.dryRun ? "DRY RUN (no data will be modified)" : `LIVE — ${config.column} will be set`}`
+  );
+  if (cliArgs.state) console.log(`  State filter: ${cliArgs.state}`);
+  if (cliArgs.skipStates.length > 0)
+    console.log(`  Skipping states: ${cliArgs.skipStates.join(", ")}`);
+  console.log();
+
+  const dbUrl = process.env.SUPABASE_DB_URL;
+  if (!dbUrl) {
+    console.error("ERROR: SUPABASE_DB_URL not set. Use --env-file=.env.local");
+    process.exit(1);
+  }
+  const poolerUrl = dbUrl.replace(/:5432\//, ":6543/");
+  const pgPool = new PgPool({
+    connectionString: poolerUrl,
+    ssl: { rejectUnauthorized: false },
+    max: 2,
+    idleTimeoutMillis: 30000,
+    connectionTimeoutMillis: 30000,
+    keepAlive: true,
+    keepAliveInitialDelayMillis: 10000,
+  });
+  pgPool.on("error", (err) => {
+    console.warn(`  Pool background error (non-fatal): ${err.message}`);
+  });
+  await pgPool.query("SELECT 1");
+  console.log("  Postgres pool connected\n");
+
+  try {
+    await pgPool.query(config.smokeTestSql);
+  } catch {
+    console.error(config.smokeTestError);
+    process.exit(1);
+  }
+
+  let states: string[];
+  if (cliArgs.state) {
+    states = [cliArgs.state];
+  } else {
+    const { rows } = await pgPool.query(
+      "SELECT DISTINCT state FROM providers WHERE state IS NOT NULL ORDER BY state"
+    );
+    states = rows.map((r: { state: string }) => r.state);
+  }
+
+  const results: StateResult[] = [];
+  let grandTotalUpdated = 0;
+  const overallStart = Date.now();
+
+  for (const state of states) {
+    if (cliArgs.skipStates.includes(state)) {
+      console.log(`  [${ts()}] ${state}: skipping`);
+      continue;
+    }
+
+    try {
+      await pgPool.query("SELECT 1");
+    } catch {
+      console.warn(
+        `  [${ts()}] ${state}: Postgres health check failed, waiting 10s...`
+      );
+      await new Promise((r) => setTimeout(r, 10000));
+      try {
+        await pgPool.query("SELECT 1");
+        console.log(`  [${ts()}] ${state}: reconnected after retry`);
+      } catch (retryErr) {
+        console.error(
+          `  [${ts()}] ${state}: SKIPPING — Postgres unreachable (${retryErr instanceof Error ? retryErr.message : retryErr})`
+        );
+        continue;
+      }
+    }
+
+    const stateStart = Date.now();
+    const client = await pgPool.connect();
+
+    try {
+      await client.query("SET statement_timeout = 0");
+
+      const {
+        rows: [{ cnt: total }],
+      } = await client.query(STATE_COUNT_SQL, [state]);
+
+      let updated: number;
+      if (cliArgs.dryRun) {
+        const {
+          rows: [{ cnt }],
+        } = await client.query(config.dryRunSql, [state]);
+        updated = cnt;
+      } else {
+        const result = await client.query(config.backfillSql, [state]);
+        updated = result.rowCount ?? 0;
+      }
+
+      const elapsed = (Date.now() - stateStart) / 1000;
+      results.push({
+        state,
+        total,
+        updated,
+        elapsedSec: parseFloat(elapsed.toFixed(1)),
+      });
+      grandTotalUpdated += updated;
+
+      if (updated > 0) {
+        const pct = ((updated / total) * 100).toFixed(1);
+        console.log(
+          `  [${ts()}] ${state}: ${updated.toLocaleString()} / ${total.toLocaleString()} ` +
+            `(${pct}%) ${cliArgs.dryRun ? "would be" : ""} updated (${elapsed.toFixed(1)}s)`
+        );
+      } else {
+        console.log(
+          `  [${ts()}] ${state}: ${total.toLocaleString()} charges, none matched (${elapsed.toFixed(1)}s)`
+        );
+      }
+
+      client.release();
+    } catch (err) {
+      client.release(true);
+      console.error(
+        `  [${ts()}] ${state}: ERROR — ${err instanceof Error ? err.message : err}`
+      );
+    }
+  }
+
+  const overallElapsed = ((Date.now() - overallStart) / 1000).toFixed(1);
+
+  console.log("\n── Summary ──\n");
+  console.log(`  Mode:            ${cliArgs.dryRun ? "DRY RUN" : "LIVE"}`);
+  console.log(`  Total updated:   ${grandTotalUpdated.toLocaleString()}`);
+  console.log(`  Duration:        ${overallElapsed}s`);
+
+  if (!cliArgs.dryRun && !cliArgs.state) {
+    console.log(`\n── ${config.label} Distribution ──\n`);
+    const { rows: distRows } = await pgPool.query(config.distributionSql);
+    for (const row of distRows) {
+      const value = row[config.column] ?? "(null)";
+      console.log(`  ${value}: ${Number(row.cnt).toLocaleString()}`);
+    }
+  }
+
+  console.log("\n── JSON Summary ──\n");
+  console.log(
+    JSON.stringify(
+      {
+        mode: cliArgs.dryRun ? "dry_run" : "live",
+        totalUpdated: grandTotalUpdated,
+        durationSec: parseFloat(overallElapsed),
+        states: results,
+      },
+      null,
+      2
+    )
+  );
+
+  await pgPool.end();
+  console.log("\n  Done.");
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -102,29 +102,34 @@ create or replace function parse_laterality(
   p_modifiers text
 )
 returns text
-language sql
+language plpgsql
 immutable
 as $$
-  select case
-    when p_modifiers is not null and upper(p_modifiers) ~ '\m50\M'
-      then 'bilateral'
-    when p_modifiers is not null and upper(p_modifiers) ~ '\mLT\M'
-      then 'left'
-    when p_modifiers is not null and upper(p_modifiers) ~ '\mRT\M'
-      then 'right'
-    -- no \mBI\M here — too many false positives (BI-RADS, BI-V, etc.)
-    when p_description is not null and upper(p_description) ~ '\mLT\M'
-      then 'left'
-    when p_description is not null and upper(p_description) ~ '\mRT\M'
-      then 'right'
-    when p_description is not null and (upper(p_description) ~ '\mBILATERAL\M' or upper(p_description) ~ '\mBILAT\M')
-      then 'bilateral'
-    when p_description is not null and upper(p_description) ~ '\mLEFT\M'
-      then 'left'
-    when p_description is not null and upper(p_description) ~ '\mRIGHT\M'
-      then 'right'
-    else null
-  end;
+declare
+  v_desc text;
+  v_mods text;
+begin
+  v_mods := upper(p_modifiers);
+  v_desc := upper(p_description);
+
+  -- Modifiers take priority
+  if v_mods is not null then
+    if v_mods ~ '\m50\M' then return 'bilateral'; end if;
+    if v_mods ~ '\mLT\M' then return 'left'; end if;
+    if v_mods ~ '\mRT\M' then return 'right'; end if;
+  end if;
+
+  -- Fall back to description
+  if v_desc is not null then
+    if v_desc ~ '\mLT\M' then return 'left'; end if;
+    if v_desc ~ '\mRT\M' then return 'right'; end if;
+    if v_desc ~ '\mBILATERAL\M' or v_desc ~ '\mBILAT\M' then return 'bilateral'; end if;
+    if v_desc ~ '\mLEFT\M' then return 'left'; end if;
+    if v_desc ~ '\mRIGHT\M' then return 'right'; end if;
+  end if;
+
+  return null;
+end;
 $$;
 
 -- ============================================================================
@@ -132,57 +137,47 @@ $$;
 -- ============================================================================
 create or replace function parse_body_site(p_description text)
 returns text
-language sql
+language plpgsql
 immutable
 as $$
-  select case
-    -- Generic exclusions
-    when p_description is not null and upper(p_description) ~ '\mLOW(ER)?\s+EXTREMITY\s+JOINT\M'
-      then null
-    when p_description is not null and upper(p_description) ~ '\mUPPER\s+EXTREMITY\s+JOINT\M'
-      then null
-    when p_description is not null and upper(p_description) ~ '\mANY\s+JOINT\M'
-      then null
-    -- Joints
-    when p_description is not null and upper(p_description) ~ '\mKNEE\M'
-      then 'knee'
-    when p_description is not null and upper(p_description) ~ '\mHIP\M'
-      then 'hip'
-    when p_description is not null and upper(p_description) ~ '\mANKLE\M'
-      then 'ankle'
-    when p_description is not null and upper(p_description) ~ '\mSHOULDER\M'
-      then 'shoulder'
-    when p_description is not null and upper(p_description) ~ '\mELBOW\M'
-      then 'elbow'
-    when p_description is not null and upper(p_description) ~ '\mWRIST\M'
-      then 'wrist'
-    when p_description is not null and upper(p_description) ~ '\mHAND\M'
-      then 'hand'
-    when p_description is not null and (upper(p_description) ~ '\mFOOT\M' or upper(p_description) ~ '\mFEET\M')
-      then 'foot'
-    -- Spine segments
-    when p_description is not null and (upper(p_description) ~ '\mCERVICAL\M' or upper(p_description) ~ '\mC[\s-]?SPINE\M')
-      then 'cervical_spine'
-    when p_description is not null and (upper(p_description) ~ '\mTHORACIC\M' or upper(p_description) ~ '\mT[\s-]?SPINE\M')
-      then 'thoracic_spine'
-    when p_description is not null and (upper(p_description) ~ '\mLUMBAR\M' or upper(p_description) ~ '\mL[\s-]?SPINE\M')
-      then 'lumbar_spine'
-    when p_description is not null and (upper(p_description) ~ '\mSACRAL\M' or upper(p_description) ~ '\mSACRUM\M')
-      then 'sacral_spine'
-    -- Torso/body regions
-    when p_description is not null and upper(p_description) ~ '\mCHEST\M'
-      then 'chest'
-    when p_description is not null and (upper(p_description) ~ '\mABDOMEN\M' or upper(p_description) ~ '\mABDOMINAL\M')
-      then 'abdomen'
-    when p_description is not null and upper(p_description) ~ '\mPELVI[SC]\M'
-      then 'pelvis'
-    -- Head/neck
-    when p_description is not null and (upper(p_description) ~ '\mHEAD\M' or upper(p_description) ~ '\mBRAIN\M' or upper(p_description) ~ '\mCRANIAL\M')
-      then 'head'
-    when p_description is not null and upper(p_description) ~ '\mNECK\M'
-      then 'neck'
-    else null
-  end;
+declare
+  v_desc text;
+begin
+  if p_description is null then return null; end if;
+  v_desc := upper(p_description);
+
+  -- Generic exclusions (must come first)
+  if v_desc ~ '\mLOW(ER)?\s+EXTREMITY\s+JOINT\M' then return null; end if;
+  if v_desc ~ '\mUPPER\s+EXTREMITY\s+JOINT\M' then return null; end if;
+  if v_desc ~ '\mANY\s+JOINT\M' then return null; end if;
+
+  -- Joints (most specific first)
+  if v_desc ~ '\mKNEE\M' then return 'knee'; end if;
+  if v_desc ~ '\mHIP\M' then return 'hip'; end if;
+  if v_desc ~ '\mANKLE\M' then return 'ankle'; end if;
+  if v_desc ~ '\mSHOULDER\M' then return 'shoulder'; end if;
+  if v_desc ~ '\mELBOW\M' then return 'elbow'; end if;
+  if v_desc ~ '\mWRIST\M' then return 'wrist'; end if;
+  if v_desc ~ '\mHAND\M' then return 'hand'; end if;
+  if v_desc ~ '\mFOOT\M' or v_desc ~ '\mFEET\M' then return 'foot'; end if;
+
+  -- Spine segments
+  if v_desc ~ '\mCERVICAL\M' or v_desc ~ '\mC[\s-]?SPINE\M' then return 'cervical_spine'; end if;
+  if v_desc ~ '\mTHORACIC\M' or v_desc ~ '\mT[\s-]?SPINE\M' then return 'thoracic_spine'; end if;
+  if v_desc ~ '\mLUMBAR\M' or v_desc ~ '\mL[\s-]?SPINE\M' then return 'lumbar_spine'; end if;
+  if v_desc ~ '\mSACRAL\M' or v_desc ~ '\mSACRUM\M' then return 'sacral_spine'; end if;
+
+  -- Torso/body regions
+  if v_desc ~ '\mCHEST\M' then return 'chest'; end if;
+  if v_desc ~ '\mABDOMEN\M' or v_desc ~ '\mABDOMINAL\M' then return 'abdomen'; end if;
+  if v_desc ~ '\mPELVI[SC]\M' then return 'pelvis'; end if;
+
+  -- Head/neck
+  if v_desc ~ '\mHEAD\M' or v_desc ~ '\mBRAIN\M' or v_desc ~ '\mCRANIAL\M' then return 'head'; end if;
+  if v_desc ~ '\mNECK\M' then return 'neck'; end if;
+
+  return null;
+end;
 $$;
 
 -- ============================================================================


### PR DESCRIPTION
## Summary

Post-merge cleanup of PR #85 (body-site laterality). Consolidates duplicated code, optimizes SQL functions, and extracts shared backfill infrastructure.

- **Shared utilities**: `normalizeCodeType` (3→1), `normalizeCodeValue` (2→1), generic `extractFromSet<T>` helper
- **Shared backfill runner**: `scripts/lib/run-backfill.ts` replaces ~240 duplicated lines across laterality + body-site backfill scripts
- **CTE-based backfill SQL**: Parse function called once per row instead of twice (WHERE + SET)
- **plpgsql parse functions**: `parse_laterality` and `parse_body_site` rewritten to hoist `upper()` into local variable (20× → 1× per row)
- **LookupFilters bundle**: laterality + bodySite threaded as single object through lookup chain, reducing parameter sprawl

SQL functions already deployed to Supabase and verified.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes (0 errors)
- [x] SQL functions verified: `parse_body_site('MR KNEE NO IV CONTRAST')` → `knee`, `parse_laterality('MRI KNEE RT', 'RT')` → `right`
- [ ] Verify search still works end-to-end on deployed app

🤖 Generated with [Claude Code](https://claude.com/claude-code)