### PR TITLE
Compact results page: accordion cards + collapsible banner

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -283,3 +283,21 @@ html {
   color: var(--cc-text);
   box-shadow: 0 1px 3px rgba(26, 26, 46, 0.08);
 }
+
+/* ============================================================================
+   Accordion (CSS Grid height animation)
+   ============================================================================ */
+
+.accordion-body {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.25s ease-out;
+}
+
+.accordion-body.expanded {
+  grid-template-rows: 1fr;
+}
+
+.accordion-body > div {
+  overflow: hidden;
+}

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { Suspense, useCallback, useMemo } from "react";
+import { Suspense, useCallback, useMemo, useState } from "react";
 import { SearchBar } from "@/components/SearchBar";
 import { ResultsList } from "@/components/ResultsList";
 import { FilterBar } from "@/components/FilterBar";
 import { MapView } from "@/components/MapView";
 import { SaveButton } from "@/components/SaveButton";
 import { CostContextBanner } from "@/components/CostContextBanner";
+import type { CPTCode, PricingPlan } from "@/types";
 import { useResultsSearch } from "./useResultsSearch";
 import { useResultSelection } from "./useResultSelection";
 
@@ -56,7 +57,7 @@ function ResultsContent() {
   }, [cptCodes]);
 
   return (
-    <div className="px-4 py-5">
+    <div className="px-4 py-3">
       {/* Header section — constrained width */}
       <div className="max-w-5xl mx-auto lg:max-w-7xl">
         {/* Search bar (compact) */}
@@ -70,64 +71,13 @@ function ResultsContent() {
           compact
         />
 
-        {/* Interpretation banner */}
+        {/* Interpretation banner (collapsible) */}
         {interpretation && !loading && (
-          <div
-            className="mt-4 p-4 rounded-xl border animate-fade-in"
-            style={{
-              background: "var(--cc-primary-light)",
-              borderColor: "rgba(15, 118, 110, 0.12)",
-            }}
-          >
-            <div className="flex items-start gap-2.5">
-              <svg
-                className="w-4 h-4 mt-0.5 shrink-0"
-                style={{ color: "var(--cc-primary)" }}
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <path d="M12 8V4H8" />
-                <rect width="16" height="12" x="4" y="8" rx="2" />
-                <path d="M2 14h2M20 14h2M15 13v2M9 13v2" />
-              </svg>
-              <div>
-                <p className="text-sm" style={{ color: "var(--cc-primary)" }}>
-                  <span className="font-semibold">Interpreted as:</span>{" "}
-                  {interpretation}
-                </p>
-                {pricingPlan?.mode === "encounter_first" && (
-                  <p
-                    className="text-xs mt-1.5"
-                    style={{ color: "var(--cc-primary)" }}
-                  >
-                    Showing a visit-first estimate; any imaging or lab work is
-                    listed below as possible additional costs.
-                  </p>
-                )}
-                {cptCodes.length > 0 && (
-                  <div className="flex flex-wrap gap-1.5 mt-2">
-                    {cptCodes.map((code) => (
-                      <span
-                        key={code.code}
-                        className="text-xs px-2 py-0.5 rounded-md font-medium"
-                        style={{
-                          background: "rgba(15, 118, 110, 0.1)",
-                          color: "var(--cc-primary)",
-                        }}
-                      >
-                        {(code.codeType || "CPT").toUpperCase()} {code.code}:{" "}
-                        {code.description}
-                      </span>
-                    ))}
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
+          <InterpretationBanner
+            interpretation={interpretation}
+            pricingPlan={pricingPlan}
+            cptCodes={cptCodes}
+          />
         )}
 
         {/* Error state */}
@@ -151,7 +101,7 @@ function ResultsContent() {
         )}
 
         {/* Toolbar: View toggle (mobile only) + Save + Filters */}
-        <div className="mt-4">
+        <div className="mt-2">
           <div className="flex flex-wrap items-center gap-2 lg:flex-nowrap lg:justify-between">
             {/* Toggle pills: mobile only */}
             <div className="lg:hidden">
@@ -263,6 +213,132 @@ function ResultsContent() {
               selectedResultId={selectedResultId}
               className="h-full"
             />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function InterpretationBanner({
+  interpretation,
+  pricingPlan,
+  cptCodes,
+}: {
+  interpretation: string;
+  pricingPlan: PricingPlan | undefined;
+  cptCodes: CPTCode[];
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const firstTwoCodes = cptCodes.slice(0, 2);
+  const overflowCount = cptCodes.length - 2;
+
+  return (
+    <div
+      className="mt-2 rounded-xl border animate-fade-in"
+      style={{
+        background: "var(--cc-primary-light)",
+        borderColor: "rgba(15, 118, 110, 0.12)",
+      }}
+    >
+      {/* Collapsed row */}
+      <button
+        className="w-full flex items-center gap-2 px-3 py-2 text-left"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+      >
+        <svg
+          className="w-4 h-4 shrink-0"
+          style={{ color: "var(--cc-primary)" }}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M12 8V4H8" />
+          <rect width="16" height="12" x="4" y="8" rx="2" />
+          <path d="M2 14h2M20 14h2M15 13v2M9 13v2" />
+        </svg>
+        <span
+          className="text-sm truncate min-w-0"
+          style={{ color: "var(--cc-primary)" }}
+        >
+          <span className="font-semibold">Interpreted as:</span>{" "}
+          {interpretation}
+        </span>
+        {!expanded && cptCodes.length > 0 && (
+          <span className="flex items-center gap-1 shrink-0">
+            {firstTwoCodes.map((code) => (
+              <span
+                key={code.code}
+                className="text-[11px] px-1.5 py-0.5 rounded-md font-medium hidden sm:inline"
+                style={{
+                  background: "rgba(15, 118, 110, 0.1)",
+                  color: "var(--cc-primary)",
+                }}
+              >
+                {(code.codeType || "CPT").toUpperCase()} {code.code}
+              </span>
+            ))}
+            {overflowCount > 0 && (
+              <span
+                className="text-[11px] font-medium hidden sm:inline"
+                style={{ color: "var(--cc-primary)" }}
+              >
+                +{overflowCount}
+              </span>
+            )}
+          </span>
+        )}
+        <svg
+          className="w-4 h-4 shrink-0 transition-transform duration-200"
+          style={{
+            color: "var(--cc-primary)",
+            transform: expanded ? "rotate(180deg)" : "rotate(0deg)",
+          }}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+
+      {/* Expanded content */}
+      <div className={`accordion-body ${expanded ? "expanded" : ""}`}>
+        <div>
+          <div className="px-3 pb-3">
+            {pricingPlan?.mode === "encounter_first" && (
+              <p
+                className="text-xs mb-2"
+                style={{ color: "var(--cc-primary)" }}
+              >
+                Showing a visit-first estimate; any imaging or lab work is
+                listed below as possible additional costs.
+              </p>
+            )}
+            {cptCodes.length > 0 && (
+              <div className="flex flex-wrap gap-1.5">
+                {cptCodes.map((code) => (
+                  <span
+                    key={code.code}
+                    className="text-xs px-2 py-0.5 rounded-md font-medium"
+                    style={{
+                      background: "rgba(15, 118, 110, 0.1)",
+                      color: "var(--cc-primary)",
+                    }}
+                  >
+                    {(code.codeType || "CPT").toUpperCase()} {code.code}:{" "}
+                    {code.description}
+                  </span>
+                ))}
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/components/ResultCard.tsx
+++ b/components/ResultCard.tsx
@@ -17,6 +17,8 @@ interface ResultCardProps {
   result: ChargeResult;
   rank: number;
   isSelected?: boolean;
+  isExpanded?: boolean;
+  onToggleExpand?: () => void;
   codeDescriptionMap?: Record<string, string>;
 }
 
@@ -42,6 +44,8 @@ export function ResultCard({
   result,
   rank,
   isSelected,
+  isExpanded,
+  onToggleExpand,
   codeDescriptionMap,
 }: ResultCardProps) {
   const billingCode = formatBillingCode(result);
@@ -73,10 +77,17 @@ export function ResultCard({
     return null;
   })();
 
+  const priceColor =
+    displayPrice.type === "cash"
+      ? "var(--cc-primary)"
+      : displayPrice.type === "insured"
+        ? "var(--cc-info)"
+        : "var(--cc-text-tertiary)";
+
   return (
     <div
       data-result-id={result.id}
-      className="card-hover rounded-xl border overflow-hidden transition-all duration-300"
+      className={`rounded-xl border overflow-hidden transition-all duration-300 ${isExpanded ? "card-hover" : ""}`}
       style={{
         background: isSelected
           ? "var(--cc-primary-light)"
@@ -95,336 +106,391 @@ export function ResultCard({
           }}
         />
 
-        {/* Card content */}
-        <div className="flex-1 p-4">
-          {/* Header row */}
-          <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-2 sm:gap-4">
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2 flex-wrap">
-                <span
-                  className="inline-flex items-center justify-center w-6 h-6 rounded-lg text-xs font-semibold shrink-0"
-                  style={{
-                    background:
-                      rank <= 3
-                        ? "var(--cc-primary-light)"
-                        : "var(--cc-surface-alt)",
-                    color:
-                      rank <= 3
-                        ? "var(--cc-primary)"
-                        : "var(--cc-text-tertiary)",
-                  }}
-                >
-                  {rank}
-                </span>
-                <h3
-                  className="font-semibold text-base truncate"
-                  style={{ color: "var(--cc-text)" }}
-                >
-                  {result.provider.name}
-                </h3>
-                {result.setting && (
-                  <span
-                    className="text-xs px-2 py-0.5 rounded-md font-medium shrink-0"
-                    style={{
-                      background: "var(--cc-surface-alt)",
-                      color: "var(--cc-text-tertiary)",
-                    }}
-                  >
-                    {result.setting}
-                  </span>
-                )}
-              </div>
-
-              {address && (
-                <p
-                  className="text-sm mt-1 truncate"
-                  style={{ color: "var(--cc-text-secondary)" }}
-                >
-                  {address}
-                </p>
-              )}
-
-              <div className="flex items-center gap-2 mt-1 flex-wrap">
-                {billingCode && (
-                  <span
-                    className="text-xs font-medium px-1.5 py-0.5 rounded"
-                    style={{
-                      background: "var(--cc-primary-light)",
-                      color: "var(--cc-primary)",
-                    }}
-                  >
-                    {billingCode}
-                  </span>
-                )}
-                {displayDescription && (
-                  <span
-                    className="text-xs truncate"
-                    style={{ color: "var(--cc-text-tertiary)" }}
-                    title={rawTooltip}
-                  >
-                    {displayDescription}
-                  </span>
-                )}
-              </div>
-            </div>
-
-            {/* Price column */}
-            <div className="text-left sm:text-right sm:shrink-0">
-              {displayPrice.type === "cash" ? (
-                <>
-                  {result.grossCharge != null &&
-                    result.grossCharge > (result.cashPrice || 0) && (
-                      <p
-                        className="text-xs line-through"
-                        style={{ color: "var(--cc-text-tertiary)" }}
-                      >
-                        {formatPrice(result.grossCharge)}
-                      </p>
-                    )}
-                  <p
-                    className="text-2xl font-bold"
-                    style={{ color: "var(--cc-primary)" }}
-                  >
-                    {formatDisplayPrice(displayPrice)}
-                  </p>
-                  <p
-                    className="text-xs mt-0.5"
-                    style={{ color: "var(--cc-text-tertiary)" }}
-                  >
-                    {displayPrice.label}
-                  </p>
-                  {result.baseSource === "local_fallback" && (
-                    <p
-                      className="text-[11px] mt-1"
-                      style={{ color: "var(--cc-text-tertiary)" }}
-                    >
-                      Local estimate fallback
-                    </p>
-                  )}
-                </>
-              ) : displayPrice.type === "insured" ? (
-                <>
-                  <p
-                    className="text-2xl font-bold"
-                    style={{ color: "var(--cc-info)" }}
-                  >
-                    {formatDisplayPrice(displayPrice)}
-                    <span
-                      className="inline-block ml-1 align-middle cursor-help"
-                      title="Average rate negotiated between this hospital and insurers. Your actual cost depends on your specific plan."
-                    >
-                      <svg
-                        className="w-4 h-4 inline"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                      >
-                        <circle cx="12" cy="12" r="10" />
-                        <path d="M12 16v-4" />
-                        <path d="M12 8h.01" />
-                      </svg>
-                    </span>
-                  </p>
-                  <p
-                    className="text-xs mt-0.5"
-                    style={{ color: "var(--cc-text-tertiary)" }}
-                  >
-                    {displayPrice.label}
-                  </p>
-                </>
-              ) : (
-                <p
-                  className="text-sm"
-                  style={{ color: "var(--cc-text-tertiary)" }}
-                >
-                  Price unavailable
-                </p>
-              )}
-
-              {displayPrice.type === "cash" &&
-                result.minPrice != null &&
-                result.maxPrice != null && (
-                  <p
-                    className="text-xs mt-0.5"
-                    style={{ color: "var(--cc-text-tertiary)" }}
-                  >
-                    {formatPrice(result.minPrice)} &ndash;{" "}
-                    {formatPrice(result.maxPrice)}
-                  </p>
-                )}
-              {result.estimatedTotalMedian != null && (
-                <p
-                  className="text-xs mt-1.5"
-                  style={{ color: "var(--cc-text-secondary)" }}
-                >
-                  Est. total: {formatPrice(result.estimatedTotalMedian)}
-                </p>
-              )}
-            </div>
-          </div>
-
-          {/* Billing class callout */}
-          {billingClassCallout && (
-            <div
-              className="flex items-start gap-1.5 mt-2"
-              style={{ color: "var(--cc-accent)" }}
-            >
-              <svg
-                className="w-3.5 h-3.5 shrink-0 mt-0.5"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <circle cx="12" cy="12" r="10" />
-                <path d="M12 16v-4" />
-                <path d="M12 8h.01" />
-              </svg>
-              <span className="text-xs">{billingClassCallout}</span>
-            </div>
-          )}
-
-          {/* Footer row */}
+        <div className="flex-1 min-w-0">
+          {/* Collapsed header row — always visible */}
           <div
-            className="mt-3 pt-3 flex items-center justify-between flex-wrap gap-2"
-            style={{ borderTop: "1px solid var(--cc-border)" }}
+            className="flex items-center gap-2 px-3 py-2 cursor-pointer select-none"
+            role="button"
+            aria-expanded={isExpanded}
+            onClick={onToggleExpand}
           >
-            <div className="flex items-center gap-4">
-              {displayPrice.type !== "insured" &&
-                result.avgNegotiatedRate != null && (
-                  <div className="flex items-center gap-1.5">
-                    <span
-                      className="text-xs"
-                      style={{ color: "var(--cc-text-tertiary)" }}
-                    >
-                      Avg insured:
-                    </span>
-                    <span
-                      className="text-sm font-semibold"
-                      style={{ color: "var(--cc-info)" }}
-                    >
-                      {formatPrice(result.avgNegotiatedRate)}
-                    </span>
-                    {result.payerCount != null && result.payerCount > 0 && (
-                      <span
-                        className="text-xs"
-                        style={{ color: "var(--cc-text-tertiary)" }}
-                      >
-                        ({result.payerCount} payer
-                        {result.payerCount !== 1 ? "s" : ""})
-                      </span>
-                    )}
-                  </div>
-                )}
-            </div>
-
-            <div
-              className="flex items-center gap-3 text-xs"
-              style={{ color: "var(--cc-text-tertiary)" }}
-            >
-              {distance && (
-                <span className="flex items-center gap-1">
-                  <svg
-                    className="w-3 h-3"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" />
-                    <circle cx="12" cy="10" r="3" />
-                  </svg>
-                  {distance}
-                </span>
-              )}
-              {result.provider.phone && (
-                <a
-                  href={`tel:${result.provider.phone}`}
-                  className="hover:underline"
-                  style={{ color: "var(--cc-primary)" }}
-                >
-                  {result.provider.phone}
-                </a>
-              )}
-            </div>
-          </div>
-
-          {result.optionalAdders && result.optionalAdders.length > 0 && (
-            <div
-              className="mt-3 p-3 rounded-lg border"
+            {/* Rank badge */}
+            <span
+              className="inline-flex items-center justify-center w-5 h-5 rounded-lg text-[11px] font-semibold shrink-0"
               style={{
-                background: "var(--cc-surface-alt)",
-                borderColor: "var(--cc-border)",
+                background:
+                  rank <= 3
+                    ? "var(--cc-primary-light)"
+                    : "var(--cc-surface-alt)",
+                color:
+                  rank <= 3 ? "var(--cc-primary)" : "var(--cc-text-tertiary)",
               }}
             >
-              <p
-                className="text-xs font-semibold"
-                style={{ color: "var(--cc-text-secondary)" }}
+              {rank}
+            </span>
+
+            {/* Provider name */}
+            <span
+              className="text-sm font-semibold truncate min-w-0"
+              style={{ color: "var(--cc-text)" }}
+            >
+              {result.provider.name}
+            </span>
+
+            {/* Setting badge */}
+            {result.setting && (
+              <span
+                className="text-[11px] px-1.5 py-0.5 rounded-md font-medium shrink-0 hidden sm:inline"
+                style={{
+                  background: "var(--cc-surface-alt)",
+                  color: "var(--cc-text-tertiary)",
+                }}
               >
-                Possible additional costs (only if ordered during visit)
-              </p>
-              <div className="mt-2 space-y-1.5">
-                {result.optionalAdders.map((adder) => (
-                  <div
-                    key={`${adder.id || adder.type}-${adder.label}`}
-                    className="flex items-center justify-between gap-2"
-                  >
-                    <div className="flex items-center gap-1.5 min-w-0">
-                      <span
-                        className="text-xs font-medium"
-                        style={{ color: "var(--cc-text)" }}
-                      >
-                        {adder.label}
-                      </span>
-                      <span
-                        className="text-[11px]"
-                        style={{ color: "var(--cc-text-tertiary)" }}
-                      >
-                        {adder.source === "facility"
-                          ? "this facility"
-                          : "local estimate"}
-                      </span>
-                    </div>
-                    <span
-                      className="text-xs font-semibold shrink-0"
-                      style={{ color: "var(--cc-primary)" }}
-                    >
-                      {formatAdderPriceRange(adder)}
-                    </span>
-                  </div>
-                ))}
-              </div>
-              <p
-                className="text-[11px] mt-2"
+                {result.setting}
+              </span>
+            )}
+
+            {/* Spacer */}
+            <span className="flex-1" />
+
+            {/* Price */}
+            <span
+              className="text-sm font-bold shrink-0"
+              style={{ color: priceColor }}
+            >
+              {formatDisplayPrice(displayPrice)}
+            </span>
+
+            {/* Distance */}
+            {distance && (
+              <span
+                className="text-xs shrink-0 hidden sm:inline"
                 style={{ color: "var(--cc-text-tertiary)" }}
               >
-                Adders are separate from the base visit estimate.
-              </p>
-              {result.proxyLabel && (
-                <p
-                  className="text-[11px] mt-1"
-                  style={{ color: "var(--cc-text-tertiary)" }}
-                >
-                  {result.proxyLabel}
-                </p>
-              )}
-            </div>
-          )}
+                {distance}
+              </span>
+            )}
 
-          {/* Data source row */}
-          <div
-            className="flex items-center gap-2 mt-2 text-xs"
-            style={{ color: "var(--cc-border-strong)" }}
-          >
-            {lastUpdated && <span>Updated {lastUpdated}</span>}
-            <span>Source: Hospital MRF</span>
+            {/* Chevron */}
+            <svg
+              className="w-4 h-4 shrink-0 transition-transform duration-200"
+              style={{
+                color: "var(--cc-text-tertiary)",
+                transform: isExpanded ? "rotate(180deg)" : "rotate(0deg)",
+              }}
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <polyline points="6 9 12 15 18 9" />
+            </svg>
+          </div>
+
+          {/* Accordion body */}
+          <div className={`accordion-body ${isExpanded ? "expanded" : ""}`}>
+            <div>
+              <div className="px-4 pb-4">
+                {/* Expanded header details */}
+                <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-2 sm:gap-4">
+                  <div className="flex-1 min-w-0">
+                    {address && (
+                      <p
+                        className="text-sm truncate"
+                        style={{ color: "var(--cc-text-secondary)" }}
+                      >
+                        {address}
+                      </p>
+                    )}
+
+                    <div className="flex items-center gap-2 mt-1 flex-wrap">
+                      {billingCode && (
+                        <span
+                          className="text-xs font-medium px-1.5 py-0.5 rounded"
+                          style={{
+                            background: "var(--cc-primary-light)",
+                            color: "var(--cc-primary)",
+                          }}
+                        >
+                          {billingCode}
+                        </span>
+                      )}
+                      {displayDescription && (
+                        <span
+                          className="text-xs truncate"
+                          style={{ color: "var(--cc-text-tertiary)" }}
+                          title={rawTooltip}
+                        >
+                          {displayDescription}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* Price column */}
+                  <div className="text-left sm:text-right sm:shrink-0">
+                    {displayPrice.type === "cash" ? (
+                      <>
+                        {result.grossCharge != null &&
+                          result.grossCharge > (result.cashPrice || 0) && (
+                            <p
+                              className="text-xs line-through"
+                              style={{ color: "var(--cc-text-tertiary)" }}
+                            >
+                              {formatPrice(result.grossCharge)}
+                            </p>
+                          )}
+                        <p
+                          className="text-2xl font-bold"
+                          style={{ color: "var(--cc-primary)" }}
+                        >
+                          {formatDisplayPrice(displayPrice)}
+                        </p>
+                        <p
+                          className="text-xs mt-0.5"
+                          style={{ color: "var(--cc-text-tertiary)" }}
+                        >
+                          {displayPrice.label}
+                        </p>
+                        {result.baseSource === "local_fallback" && (
+                          <p
+                            className="text-[11px] mt-1"
+                            style={{ color: "var(--cc-text-tertiary)" }}
+                          >
+                            Local estimate fallback
+                          </p>
+                        )}
+                      </>
+                    ) : displayPrice.type === "insured" ? (
+                      <>
+                        <p
+                          className="text-2xl font-bold"
+                          style={{ color: "var(--cc-info)" }}
+                        >
+                          {formatDisplayPrice(displayPrice)}
+                          <span
+                            className="inline-block ml-1 align-middle cursor-help"
+                            title="Average rate negotiated between this hospital and insurers. Your actual cost depends on your specific plan."
+                          >
+                            <svg
+                              className="w-4 h-4 inline"
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              stroke="currentColor"
+                              strokeWidth="2"
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                            >
+                              <circle cx="12" cy="12" r="10" />
+                              <path d="M12 16v-4" />
+                              <path d="M12 8h.01" />
+                            </svg>
+                          </span>
+                        </p>
+                        <p
+                          className="text-xs mt-0.5"
+                          style={{ color: "var(--cc-text-tertiary)" }}
+                        >
+                          {displayPrice.label}
+                        </p>
+                      </>
+                    ) : (
+                      <p
+                        className="text-sm"
+                        style={{ color: "var(--cc-text-tertiary)" }}
+                      >
+                        Price unavailable
+                      </p>
+                    )}
+
+                    {displayPrice.type === "cash" &&
+                      result.minPrice != null &&
+                      result.maxPrice != null && (
+                        <p
+                          className="text-xs mt-0.5"
+                          style={{ color: "var(--cc-text-tertiary)" }}
+                        >
+                          {formatPrice(result.minPrice)} &ndash;{" "}
+                          {formatPrice(result.maxPrice)}
+                        </p>
+                      )}
+                    {result.estimatedTotalMedian != null && (
+                      <p
+                        className="text-xs mt-1.5"
+                        style={{ color: "var(--cc-text-secondary)" }}
+                      >
+                        Est. total: {formatPrice(result.estimatedTotalMedian)}
+                      </p>
+                    )}
+                  </div>
+                </div>
+
+                {/* Billing class callout */}
+                {billingClassCallout && (
+                  <div
+                    className="flex items-start gap-1.5 mt-2"
+                    style={{ color: "var(--cc-accent)" }}
+                  >
+                    <svg
+                      className="w-3.5 h-3.5 shrink-0 mt-0.5"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <circle cx="12" cy="12" r="10" />
+                      <path d="M12 16v-4" />
+                      <path d="M12 8h.01" />
+                    </svg>
+                    <span className="text-xs">{billingClassCallout}</span>
+                  </div>
+                )}
+
+                {/* Footer row */}
+                <div
+                  className="mt-3 pt-3 flex items-center justify-between flex-wrap gap-2"
+                  style={{ borderTop: "1px solid var(--cc-border)" }}
+                >
+                  <div className="flex items-center gap-4">
+                    {displayPrice.type !== "insured" &&
+                      result.avgNegotiatedRate != null && (
+                        <div className="flex items-center gap-1.5">
+                          <span
+                            className="text-xs"
+                            style={{ color: "var(--cc-text-tertiary)" }}
+                          >
+                            Avg insured:
+                          </span>
+                          <span
+                            className="text-sm font-semibold"
+                            style={{ color: "var(--cc-info)" }}
+                          >
+                            {formatPrice(result.avgNegotiatedRate)}
+                          </span>
+                          {result.payerCount != null &&
+                            result.payerCount > 0 && (
+                              <span
+                                className="text-xs"
+                                style={{ color: "var(--cc-text-tertiary)" }}
+                              >
+                                ({result.payerCount} payer
+                                {result.payerCount !== 1 ? "s" : ""})
+                              </span>
+                            )}
+                        </div>
+                      )}
+                  </div>
+
+                  <div
+                    className="flex items-center gap-3 text-xs"
+                    style={{ color: "var(--cc-text-tertiary)" }}
+                  >
+                    {distance && (
+                      <span className="flex items-center gap-1">
+                        <svg
+                          className="w-3 h-3"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        >
+                          <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" />
+                          <circle cx="12" cy="10" r="3" />
+                        </svg>
+                        {distance}
+                      </span>
+                    )}
+                    {result.provider.phone && (
+                      <a
+                        href={`tel:${result.provider.phone}`}
+                        className="hover:underline"
+                        style={{ color: "var(--cc-primary)" }}
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        {result.provider.phone}
+                      </a>
+                    )}
+                  </div>
+                </div>
+
+                {result.optionalAdders && result.optionalAdders.length > 0 && (
+                  <div
+                    className="mt-3 p-3 rounded-lg border"
+                    style={{
+                      background: "var(--cc-surface-alt)",
+                      borderColor: "var(--cc-border)",
+                    }}
+                  >
+                    <p
+                      className="text-xs font-semibold"
+                      style={{ color: "var(--cc-text-secondary)" }}
+                    >
+                      Possible additional costs (only if ordered during visit)
+                    </p>
+                    <div className="mt-2 space-y-1.5">
+                      {result.optionalAdders.map((adder) => (
+                        <div
+                          key={`${adder.id || adder.type}-${adder.label}`}
+                          className="flex items-center justify-between gap-2"
+                        >
+                          <div className="flex items-center gap-1.5 min-w-0">
+                            <span
+                              className="text-xs font-medium"
+                              style={{ color: "var(--cc-text)" }}
+                            >
+                              {adder.label}
+                            </span>
+                            <span
+                              className="text-[11px]"
+                              style={{ color: "var(--cc-text-tertiary)" }}
+                            >
+                              {adder.source === "facility"
+                                ? "this facility"
+                                : "local estimate"}
+                            </span>
+                          </div>
+                          <span
+                            className="text-xs font-semibold shrink-0"
+                            style={{ color: "var(--cc-primary)" }}
+                          >
+                            {formatAdderPriceRange(adder)}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                    <p
+                      className="text-[11px] mt-2"
+                      style={{ color: "var(--cc-text-tertiary)" }}
+                    >
+                      Adders are separate from the base visit estimate.
+                    </p>
+                    {result.proxyLabel && (
+                      <p
+                        className="text-[11px] mt-1"
+                        style={{ color: "var(--cc-text-tertiary)" }}
+                      >
+                        {result.proxyLabel}
+                      </p>
+                    )}
+                  </div>
+                )}
+
+                {/* Data source row */}
+                <div
+                  className="flex items-center gap-2 mt-2 text-xs"
+                  style={{ color: "var(--cc-border-strong)" }}
+                >
+                  {lastUpdated && <span>Updated {lastUpdated}</span>}
+                  <span>Source: Hospital MRF</span>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/components/ResultsList.tsx
+++ b/components/ResultsList.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useCallback } from "react";
 import type { ChargeResult } from "@/types";
 import { ResultCard } from "./ResultCard";
 
@@ -20,10 +21,42 @@ export function ResultsList({
   locationDisplay,
   onExpandRadius,
 }: ResultsListProps) {
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+
+  // Auto-expand first result on new results, and selected card on marker click
+  const [prevResults, setPrevResults] = useState(results);
+  const [prevSelectedId, setPrevSelectedId] = useState(selectedResultId);
+  if (results !== prevResults || selectedResultId !== prevSelectedId) {
+    setPrevResults(results);
+    setPrevSelectedId(selectedResultId);
+    const next =
+      results !== prevResults
+        ? results.length > 0
+          ? new Set([results[0].id])
+          : new Set<string>()
+        : new Set(expandedIds);
+    if (selectedResultId && !next.has(selectedResultId)) {
+      next.add(selectedResultId);
+    }
+    setExpandedIds(next);
+  }
+
+  const handleToggleExpand = useCallback((id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
   if (loading) {
     return (
-      <div className="space-y-3">
-        {[1, 2, 3, 4, 5, 6].map((i) => (
+      <div className="space-y-1.5">
+        {[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
           <div
             key={i}
             className="rounded-xl border overflow-hidden"
@@ -34,36 +67,13 @@ export function ResultsList({
           >
             <div className="flex">
               <div className="w-1 shrink-0 shimmer" />
-              <div className="flex-1 p-4">
-                {/* Header: rank + name on left, price on right */}
-                <div className="flex justify-between items-start gap-4">
-                  <div className="flex-1 min-w-0 space-y-2">
-                    <div className="flex items-center gap-2">
-                      <div className="w-6 h-6 rounded-lg shimmer shrink-0" />
-                      <div className="h-4 w-48 shimmer" />
-                    </div>
-                    <div className="h-3 w-64 shimmer" />
-                    <div className="flex items-center gap-2">
-                      <div className="h-4 w-12 shimmer" />
-                      <div className="h-3 w-40 shimmer" />
-                    </div>
-                  </div>
-                  <div className="shrink-0 flex flex-col items-end gap-1">
-                    <div className="h-7 w-20 shimmer" />
-                    <div className="h-3 w-14 shimmer" />
-                  </div>
-                </div>
-                {/* Footer */}
-                <div
-                  className="mt-3 pt-3 flex items-center justify-between"
-                  style={{ borderTop: "1px solid var(--cc-border)" }}
-                >
-                  <div className="h-3 w-36 shimmer" />
-                  <div className="flex items-center gap-3">
-                    <div className="h-3 w-12 shimmer" />
-                    <div className="h-3 w-24 shimmer" />
-                  </div>
-                </div>
+              <div className="flex-1 flex items-center gap-2 px-3 py-2">
+                <div className="w-5 h-5 rounded-lg shimmer shrink-0" />
+                <div className="h-4 w-40 shimmer" />
+                <div className="flex-1" />
+                <div className="h-4 w-16 shimmer shrink-0" />
+                <div className="h-3 w-12 shimmer shrink-0 hidden sm:block" />
+                <div className="w-4 h-4 shimmer shrink-0 rounded" />
               </div>
             </div>
           </div>
@@ -124,7 +134,7 @@ export function ResultsList({
   }
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-1.5">
       <p className="text-sm" style={{ color: "var(--cc-text-tertiary)" }}>
         {results.length} result{results.length !== 1 ? "s" : ""} found
       </p>
@@ -162,12 +172,14 @@ export function ResultsList({
         <div
           key={result.id}
           className="animate-fade-up"
-          style={{ animationDelay: `${i * 0.06}s` }}
+          style={{ animationDelay: `${Math.min(i, 10) * 0.04}s` }}
         >
           <ResultCard
             result={result}
             rank={i + 1}
             isSelected={result.id === selectedResultId}
+            isExpanded={expandedIds.has(result.id)}
+            onToggleExpand={() => handleToggleExpand(result.id)}
             codeDescriptionMap={codeDescriptionMap}
           />
         </div>


### PR DESCRIPTION
## Summary
- **Accordion result cards**: collapsed single-line header (~56px) showing rank, provider name, setting, price, and distance. Click to expand full details with smooth CSS grid-template-rows animation.
- **Collapsible interpretation banner**: defaults to one-line with truncated text + inline code chips, expandable for full details. Saves ~70px of vertical space.
- **Tighter spacing**: reduced outer padding, banner margins, and card gaps to maximize visible results on smaller viewports.
- First result auto-expands on load; map marker clicks auto-expand the selected card.

Target: ~8 results visible on a 900px viewport (was ~1.5).

Closes #77

## Test plan
- [ ] Search "MRI" near Weehawken — collapsed cards show rank, name, setting, price, distance
- [ ] Click a card → expands smoothly; click again → collapses
- [ ] First card auto-expanded on page load
- [ ] Click map marker → card auto-expands and scrolls into view
- [ ] Interpretation banner shows one line by default; chevron expands it
- [ ] Count visible results on ~900px viewport — target 8+
- [ ] Mobile viewport — collapsed cards still usable
- [ ] `npm run lint` passes (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)