### PR TITLE
Show gross charge when cash price not reported

### DIFF
--- a/components/MapView.tsx
+++ b/components/MapView.tsx
@@ -21,7 +21,12 @@ function buildInfoWindowContent(result: ChargeResult): string {
     notNull(result.provider.address) || notNull(result.provider.city) || "";
   const dp = getDisplayPrice(result);
   const priceStr = dp.amount != null ? formatDisplayPrice(dp) : "";
-  const priceColor = dp.type === "insured" ? "#1e40af" : "#0F766E";
+  const priceColor =
+    dp.type === "insured"
+      ? "#1e40af"
+      : dp.type === "gross"
+        ? "#D97706"
+        : "#0F766E";
   const distance = result.distanceMiles
     ? `${result.distanceMiles.toFixed(1)} mi`
     : "";

--- a/components/ResultCard.tsx
+++ b/components/ResultCard.tsx
@@ -83,7 +83,9 @@ export function ResultCard({
       ? "var(--cc-primary)"
       : displayPrice.type === "insured"
         ? "var(--cc-info)"
-        : "var(--cc-text-tertiary)";
+        : displayPrice.type === "gross"
+          ? "var(--cc-accent)"
+          : "var(--cc-text-tertiary)";
 
   return (
     <div
@@ -291,6 +293,32 @@ export function ResultCard({
                             <InfoCircleIcon className="w-4 h-4 inline" />
                           </span>
                         </p>
+                        <p
+                          className="text-xs mt-0.5"
+                          style={{ color: "var(--cc-text-tertiary)" }}
+                        >
+                          {displayPrice.label}
+                        </p>
+                      </>
+                    ) : displayPrice.type === "gross" ? (
+                      <>
+                        <p
+                          className="text-2xl font-bold"
+                          style={{ color: "var(--cc-accent)" }}
+                        >
+                          {formatDisplayPrice(displayPrice)}
+                        </p>
+                        <span
+                          className="inline-flex items-center gap-0.5 text-[11px] font-medium px-1.5 py-0.5 rounded-full cursor-help mt-0.5"
+                          style={{
+                            background: "var(--cc-accent-light)",
+                            color: "var(--cc-accent)",
+                          }}
+                          title="No cash or insured price reported. This is the hospital's chargemaster rate — there may be room to negotiate."
+                        >
+                          <InfoCircleIcon className="w-3 h-3" />
+                          List Price
+                        </span>
                         <p
                           className="text-xs mt-0.5"
                           style={{ color: "var(--cc-text-tertiary)" }}

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -7,7 +7,7 @@ export function formatPrice(price: number | undefined): string {
 
 // -- Display price waterfall: cash → insured estimate → unavailable --
 
-export type DisplayPriceType = "cash" | "insured" | "unavailable";
+export type DisplayPriceType = "cash" | "insured" | "gross" | "unavailable";
 
 export interface DisplayPrice {
   amount: number | undefined;
@@ -31,6 +31,13 @@ export function getDisplayPrice(result: ChargeResult): DisplayPrice {
       type: "insured",
     };
   }
+  if (result.grossCharge != null) {
+    return {
+      amount: result.grossCharge,
+      label: "Chargemaster rate",
+      type: "gross",
+    };
+  }
   return { amount: undefined, label: "", type: "unavailable" };
 }
 
@@ -43,7 +50,8 @@ export function getDisplayPriceAmount(
 export function formatDisplayPrice(dp: DisplayPrice): string {
   if (dp.amount == null) return "N/A";
   const formatted = formatPrice(dp.amount);
-  return dp.type === "insured" ? `~${formatted}` : formatted;
+  if (dp.type === "insured") return `~${formatted}`;
+  return formatted;
 }
 
 export function formatDistance(miles: number | undefined): string {


### PR DESCRIPTION
## Summary
- Adds `"gross"` tier to the display price waterfall in `lib/format.ts` — when both cash and insured prices are null but `grossCharge` exists, show the chargemaster rate instead of "Price unavailable"
- Renders gross-charge results with the amber "List Price" badge and tooltip explaining it's a chargemaster rate with room to negotiate
- Updates MapView info window color mapping to use amber for gross-charge markers

## Test plan
- [ ] Search for a procedure and verify results that previously showed "Price unavailable" now show the gross charge with amber "List Price" badge
- [ ] Expand a gross-charge card — confirm tooltip reads "No cash or insured price reported..."
- [ ] Confirm sort works: gross-charge results sort by price alongside cash/insured
- [ ] Confirm "Cash only" filter excludes gross-charge results
- [ ] Confirm existing "List Price" badge on undiscounted cash prices still works (regression)
- [ ] Check map view: gross-charge markers show amber price in info window

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)