### PR TITLE
Research spike: SSP dataset structure & coverage analysis

### DIFF
--- a/docs/ssp-research.md
+++ b/docs/ssp-research.md
@@ -1,0 +1,300 @@
+# SSP Dataset Research — Turquoise Health Standard Service Packages
+
+Research spike for #100. Analyzed 2026-03-12.
+
+## 1. Dataset Overview
+
+**Source:** [Turquoise Health SSP](https://github.com/turquoisehealth/servicepackages.health) (open source, MIT license)
+**Methodology:** Co-occurrence analysis from ~2.7B Komodo Health Sentinel claims (30M+ patients) — ~2.2B professional + ~450M institutional claims
+**Focus:** Hospital-based outpatient services — procedures with CMS OPPS J1 status indicators (complex, high-cost)
+**Size:** 2,948 episode definition files, one CSV per principal procedure
+**Freshness:** Static dataset (no ongoing updates indicated). Claims data vintage is pre-2023.
+
+### What SSPs Are
+
+Standard Service Packages wrap all charges and codes across bills for a single encounter into a unified definition. Instead of a patient seeing separate bills for the facility fee, anesthesia, pathology, and drugs, an SSP defines which codes _typically_ appear together when a principal procedure is performed.
+
+SSPs are **encounter-based** (single visit), not episodic (multi-visit). They represent the statistical co-occurrence of billing codes, not prescriptive bundles.
+
+### What SSPs Are NOT
+
+- Not a price database — SSPs define _what_ is billed together, not _what it costs_
+- Not prescriptive — they reflect billing patterns, not clinical protocols
+- Not episodic — a knee replacement SSP covers the surgery encounter, not the full care episode (pre-op, surgery, rehab)
+- Not provider-specific — these are aggregate patterns across all providers
+
+## 2. Schema
+
+### File Structure
+
+One CSV file per principal procedure in `outputs/`:
+
+- Filename: `beta_sorted_{code}.csv` where `{code}` is the principal CPT/HCPCS code
+- 2,948 files total
+
+### CSV Schema (4 columns)
+
+| Field          | Type                    | Description                                                                                                                               |
+| -------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `cpt`          | string                  | Co-occurring code (CPT, HCPCS, revenue code, or C-code)                                                                                   |
+| `total_count`  | integer                 | Number of claims where this code appeared alongside the principal                                                                         |
+| `association`  | float                   | Frequency ratio: count / total claims with principal. Max 1.0 per claim, but can exceed 1.0 if a code appears multiple times on one claim |
+| `resolveFroms` | string (pipe-delimited) | NCCI PTP resolved codes — less-frequent codes merged into this code per CMS edit rules                                                    |
+
+### Entity Relationships
+
+```
+Principal Code (filename)
+  │
+  ├── 1:N → Component Codes (rows)
+  │         Each has: code, count, association, resolvedFroms
+  │
+  └── Component tiers (by association threshold):
+        ├── Facility fee:    association >= 0.4
+        ├── Optional:        0.3 <= association < 0.4
+        ├── Professional:    association >= 0.5
+        └── Rare/incidental: association < 0.3 (95.4% of all rows)
+```
+
+### Code Systems Present
+
+| Code Type                    | Count (unique) | Examples                                              | Notes                                                     |
+| ---------------------------- | -------------- | ----------------------------------------------------- | --------------------------------------------------------- |
+| Standard CPT (5-digit)       | 3,501          | 27447, 88305, 99152                                   | Procedures, pathology, E/M                                |
+| HCPCS Level II               | 189            | J2704 (propofol), G0416 (pathology), Q9963 (contrast) | Drugs, supplies, services                                 |
+| Revenue codes (4-digit 0xxx) | 137            | 0636 (pharmacy), 0360 (OR services), 0250 (pharmacy)  | Hospital cost centers — no standalone charges in MRF data |
+| C-codes                      | 104            | C1776, C2626                                          | CMS pass-through supplies                                 |
+| Category III CPT (####T)     | 69             | 0071T, 0200T                                          | Emerging technology codes                                 |
+| Unknown/other                | 19             | Various                                               | Edge cases                                                |
+
+### Key Observations
+
+- **Revenue codes are universal:** 0636 (pharmacy) appears in 2,890/2,948 episodes (98%). These represent hospital cost centers, not separately billable services. They signal _what departments are involved_ but don't have standalone MRF prices.
+- **Association > 1.0:** When a code appears multiple times per claim (e.g., multiple pathology specimens), the association exceeds 1.0. Q9963 (contrast media) averages 6.01 association — patients receive ~6 units per encounter.
+- **resolveFroms consolidation:** Less-frequent codes are merged into higher-frequency codes via NCCI Procedure-to-Procedure edits. E.g., 88306 resolves into 88305 — they're interchangeable pathology codes. This strengthens the statistical signal.
+
+## 3. Coverage Analysis
+
+### Layer 1: SSP Principal Codes vs ClearCost Code List
+
+| Metric              | Value                                |
+| ------------------- | ------------------------------------ |
+| Our codes           | 1,002                                |
+| SSP principal codes | 2,948                                |
+| **Overlap**         | **120 (12.0% of ours, 4.1% of SSP)** |
+| SSP-only            | 2,828                                |
+| Our-only            | 882                                  |
+
+**Why low overlap?** The SSP focuses on complex J1-status procedures (surgeries, cardiac caths, interventional radiology). Our code list includes many codes that SSP doesn't define packages for: office visits (99213), imaging reads (73721 MRI), lab tests (80053 CMP), anesthesia codes (00142). These simpler services ARE components of SSP episodes, but they don't have their own SSP definitions.
+
+All 120 overlap codes are standard CPT. No HCPCS overlap (our HCPCS codes like J-codes are component services, not principal procedures in SSP's model).
+
+**Sample overlap codes:** 27447 (knee replacement), 27130 (hip replacement), 19083 (breast biopsy), 19301 (mastectomy), 66984 (cataract surgery), 49505 (hernia repair), 45380 — colonoscopy is NOT in the overlap (no SSP file).
+
+### Layer 2: Component Code Charge Coverage (Supabase)
+
+For the 120 overlap episodes, we extracted all facility-tier (association >= 0.4) component codes and checked Supabase for price data:
+
+| Metric                               | Value           |
+| ------------------------------------ | --------------- |
+| Unique component codes (all types)   | 295             |
+| Billable component codes (CPT/HCPCS) | 232             |
+| **Codes with Supabase charges**      | **158 (68.1%)** |
+| Missing from Supabase                | 74              |
+| **Median per-episode coverage**      | **75.0%**       |
+| Episodes with 100% coverage          | 12/120          |
+| Episodes with 0% coverage            | 0/120           |
+
+**Per-episode breakdown (selected):**
+
+| Episode                          | Billable Components | Priceable | Coverage | Revenue Codes |
+| -------------------------------- | ------------------- | --------- | -------- | ------------- |
+| 27447 (knee replacement)         | 16                  | 10        | 63%      | 13            |
+| 27130 (hip replacement)          | 13                  | 10        | 77%      | 12            |
+| 50543 (laparoscopic nephrectomy) | 15                  | 12        | 80%      | 10            |
+| 23472 (shoulder replacement)     | 11                  | 9         | 82%      | 9             |
+| 19303 (mastectomy)               | 13                  | 7         | 54%      | 10            |
+| 93656 (cardiac ablation)         | 14                  | 7         | 50%      | 10            |
+
+### Layer 3: Gap Analysis
+
+**4,019 unique component codes** appear across all 2,948 SSP episodes (at the facility tier).
+
+**Code list expansion candidates** — CPT/HCPCS codes appearing in 10+ episodes with avg association >= 0.3, that we don't currently carry:
+
+| Code  | Type  | Episodes | Avg Assoc | What It Is                           |
+| ----- | ----- | -------- | --------- | ------------------------------------ |
+| J2704 | HCPCS | 2,406    | 0.63      | Propofol (anesthesia)                |
+| J7120 | HCPCS | 399      | 0.50      | Normal saline (IV fluid)             |
+| J1170 | HCPCS | 397      | 0.56      | Hydromorphone (pain)                 |
+| 88323 | CPT   | 147      | 1.19      | Pathology consultation               |
+| Q9963 | HCPCS | 75       | 6.01      | Contrast media (per mL)              |
+| G0416 | HCPCS | 64       | 1.45      | Surgical pathology                   |
+| J3490 | HCPCS | 63       | 0.87      | Unclassified drugs                   |
+| 88325 | CPT   | 61       | 1.21      | Pathology review                     |
+| J0330 | HCPCS | 59       | 0.53      | Succinylcholine (paralytic)          |
+| 28297 | CPT   | 52       | 0.96      | Bunionectomy w/ metatarsal osteotomy |
+| 99152 | CPT   | 29       | 0.72      | Moderate sedation                    |
+
+Total expansion candidates: **48 codes**. Adding these would improve SSP episode coverage.
+
+**Structural gaps (un-priceable):**
+
+- **137 revenue codes** — hospital cost center identifiers (OR services, pharmacy, recovery). Not separately priced in MRFs.
+- **104 C-codes** — CMS pass-through supplies and devices (C1776 = joint prosthesis). Sometimes have MRF prices but inconsistently.
+- Revenue code 0636 (pharmacy) appears in 98% of all episodes but has no standalone price — it's an institutional billing artifact.
+
+## 4. Data Model Recommendations
+
+### Proposed `episode_definitions` Table
+
+```sql
+create table episode_definitions (
+  id uuid primary key default gen_random_uuid(),
+  -- Identity
+  ssp_code text unique not null,         -- Turquoise SSP identifier (= principal CPT)
+  principal_code text not null,          -- Primary procedure code
+  principal_code_type text not null,     -- 'cpt', 'hcpcs'
+  label text not null,                   -- Human-readable name ("Knee Replacement")
+  category text,                         -- Grouping: 'orthopedic', 'cardiac', etc.
+
+  -- Metadata
+  source text default 'turquoise_ssp',
+  source_claim_count integer,            -- N claims underlying the SSP
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create table episode_components (
+  id uuid primary key default gen_random_uuid(),
+  episode_id uuid not null references episode_definitions(id) on delete cascade,
+
+  -- Component identity
+  code text not null,
+  code_type text not null,               -- 'cpt', 'hcpcs', 'revenue_code'
+  tier text not null,                    -- 'required', 'expected', 'optional'
+  billing_class text,                    -- 'facility', 'professional'
+
+  -- Statistical weights from SSP
+  association float not null,            -- 0.0-1.0+ (frequency ratio)
+  charge_weight float,                   -- % of total episode charge
+  total_count integer,                   -- Claim count
+
+  -- NCCI resolution
+  resolved_from text[],                  -- Codes merged into this one
+
+  constraint uq_episode_component unique (episode_id, code)
+);
+
+create index idx_episode_components_episode on episode_components (episode_id);
+create index idx_episode_components_code on episode_components (code);
+```
+
+### Tier Classification
+
+| Tier       | Association Threshold | Meaning                                  | Example               |
+| ---------- | --------------------- | ---------------------------------------- | --------------------- |
+| `required` | >= 0.7                | Almost always billed with this procedure | Pathology with biopsy |
+| `expected` | 0.4 - 0.7             | Usually billed, but not always           | Anesthesia drugs      |
+| `optional` | 0.3 - 0.4             | Sometimes billed                         | Contrast media        |
+
+### Grouping Key Design
+
+SSP episodes map to existing charge lookups via `principal_code`:
+
+```
+User searches "knee replacement"
+  → Claude translates to CPT 27447
+  → Search charges for 27447 (existing flow)
+  → ALSO look up episode_definitions WHERE principal_code = '27447'
+  → Get all episode_components
+  → For each component code, lookup charges at same provider
+  → Sum to estimate all-in cost
+```
+
+### Component Multiplicity
+
+| Metric          | All components | Facility-tier (assoc >= 0.4) |
+| --------------- | -------------- | ---------------------------- |
+| Min per episode | 2              | 1                            |
+| Median          | 308            | 13                           |
+| P75             | 539            | —                            |
+| Max             | 2,810          | 464                          |
+| Avg             | 407            | 14                           |
+
+The raw component lists are very long (median 308) because they include every code that ever appeared on a claim with the principal. **Only the facility-tier matters for pricing** — median 13 components, which is manageable for per-provider lookups.
+
+### Pricing Composition Feasibility
+
+For the 120 overlapping episodes:
+
+- **Median 75%** of billable component codes have charges in Supabase
+- **0 episodes** have zero coverage — every episode has _some_ priceable components
+- **12 episodes** (10%) have 100% coverage of their billable components
+
+The main gap is **J-codes** (injectable drugs) and **pathology codes** that aren't in our 1,002-code import list. These codes DO exist in the underlying Trilliant MRF data — we just didn't import them. A targeted import of the 48 expansion candidates would substantially improve episode coverage.
+
+**Revenue codes (137 unique) are un-priceable** — they represent hospital cost centers (OR, pharmacy, recovery room). They're valuable as metadata (tells you which departments are involved) but don't have standalone charges. This is a structural ceiling: even with perfect CPT/HCPCS coverage, revenue code costs are baked into facility fees.
+
+## 5. Feasibility Assessment
+
+### What % of Episodes Can We Price?
+
+| Scope                       | Coverage                                                                    |
+| --------------------------- | --------------------------------------------------------------------------- |
+| Any partial estimate        | **100%** — all 120 overlap episodes have at least some priceable components |
+| ≥50% of billable components | ~85% of episodes                                                            |
+| ≥75% of billable components | ~50% of episodes                                                            |
+| 100% of billable components | 10% of episodes                                                             |
+
+### Structural Ceiling
+
+Even with a complete code list, **revenue codes create an inherent gap**. Hospital MRFs don't publish separate prices for "OR services" (0360) or "pharmacy" (0636) — these costs are embedded in the facility fee for the procedure itself.
+
+This means the SSP approach gives us a **useful directional estimate** ("your knee replacement will involve facility, anesthesia, pathology, and drugs — here's what each costs") rather than a precise all-in total. The value is in **decomposing the bill** and flagging expected additional charges, not in summing to a guaranteed total.
+
+### Accuracy Considerations
+
+1. **Association != certainty:** A code with 0.6 association appears on 60% of claims. We're estimating what a _typical_ encounter looks like, not a specific patient's bill.
+2. **Provider variation:** Different hospitals bill different code combinations. The SSP is a national average — local patterns may differ.
+3. **Temporal lag:** Claims data is pre-2023. New drugs, techniques, or billing practices may shift patterns.
+4. **Professional fees:** Many component codes (especially with high association) are professional fees billed by independent physicians (anesthesiologists, pathologists). Hospital MRFs may not include these. This is the biggest accuracy risk.
+
+## 6. Code List Implications
+
+### Should We Expand?
+
+**Yes, but targeted.** Adding all 2,828 SSP-only principal codes would bloat our import from 8M to potentially 100M+ rows with diminishing returns. Instead:
+
+**Recommended strategy:**
+
+1. **Add the 48 expansion candidates** (J-codes, pathology, sedation) to `final-codes.json` → targeted import → immediately improves episode coverage for existing overlap episodes
+2. **Prioritize high-value SSP principal codes** that users actually search for but we don't carry (e.g., complex cardiac procedures, neurosurgery). Cross-reference with search analytics once we have them.
+3. **Don't import revenue codes or C-codes** — they don't have useful standalone prices
+
+### Import Impact
+
+Adding 48 codes at ~8K rows/code (national average) = ~384K additional charge rows. Trivial relative to our current 8.15M rows.
+
+## 7. Next Steps
+
+### For #63 (Episode Cost Estimation — Near Term)
+
+1. Create `episode_definitions` and `episode_components` tables per schema above
+2. Import the 120 overlapping SSP episodes (parse CSV → insert)
+3. Build "episode cost composition" API: given a procedure code + provider, look up the episode definition and sum available component charges from that provider
+4. Display as "estimated all-in cost" with breakdown on results page
+5. Add the 48 expansion candidate codes to the import list and run a targeted import
+
+### For #92 (Full SSP Integration — Medium Term)
+
+1. Import all 2,948 SSP episodes into `episode_definitions`
+2. Build episode search: let users find episodes by name/category, not just individual codes
+3. Cross-reference SSP principal codes against search analytics to prioritize which episodes to surface
+4. Consider adding `charge_weight` data (percentage of total claim charge per component) for weighted estimates when exact charges aren't available
+
+### Future Considerations
+
+- **Professional fee estimation:** Hospital MRFs don't include independent physician charges. For accurate all-in estimates, we'd need either physician MRF data (Phase 8+) or statistical models based on Medicare fee schedules.
+- **Episode chaining:** Turquoise notes SSPs are encounter-based, not episodic. A knee replacement _episode of care_ = pre-op testing SSP + surgery SSP + rehab SSP. Building multi-SSP episodes is a future differentiation opportunity.
+- **Provider-specific patterns:** Eventually, we could build provider-specific SSP variants using our own MRF data — "Hospital X typically bills these codes with knee replacements" vs national average.

--- a/scripts/ssp-analysis.ts
+++ b/scripts/ssp-analysis.ts
@@ -1,0 +1,736 @@
+/**
+ * SSP Dataset Analysis Script
+ *
+ * Parses Turquoise Health Standard Service Packages and analyzes overlap
+ * with ClearCost's code list and Supabase charge data.
+ *
+ * Usage: npx tsx --env-file=.env.local scripts/ssp-analysis.ts
+ *
+ * Reusable for #92 (full SSP integration).
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import { readFileSync, readdirSync } from "fs";
+import { join } from "path";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const SSP_DIR = join(process.env.HOME || "~", "Projects/ssp-data/outputs");
+const CODE_LIST_PATH = join(__dirname, "../lib/data/final-codes.json");
+
+// Association thresholds (from Turquoise methodology)
+const FACILITY_THRESHOLD = 0.4;
+const OPTIONAL_LOWER = 0.3;
+
+// Code classification regex
+const REVENUE_CODE_RE = /^0\d{3}$/; // 4-digit starting with 0
+const HCPCS_LEVEL2_RE = /^[A-VX-Z]\d{4}$/; // Letter + 4 digits (A-V, X-Z)
+const CPT_CAT3_RE = /^\d{4}T$/; // Category III CPT (####T)
+const CPT_STANDARD_RE = /^\d{5}$/; // Standard 5-digit CPT
+const C_CODE_RE = /^C\d{4}$/; // C-codes (HCPCS C category)
+
+type CodeType =
+  | "cpt"
+  | "hcpcs"
+  | "revenue_code"
+  | "c_code"
+  | "cpt_cat3"
+  | "unknown";
+
+// Code types that represent separately billable services (not institutional cost centers)
+const BILLABLE_CODE_TYPES: readonly CodeType[] = ["cpt", "hcpcs", "cpt_cat3"];
+
+function classifyCode(code: string): CodeType {
+  if (REVENUE_CODE_RE.test(code)) return "revenue_code";
+  if (C_CODE_RE.test(code)) return "c_code";
+  if (CPT_CAT3_RE.test(code)) return "cpt_cat3";
+  if (HCPCS_LEVEL2_RE.test(code)) return "hcpcs";
+  if (CPT_STANDARD_RE.test(code)) return "cpt";
+  // W-codes are HCPCS too, catch any letter+digits pattern
+  if (/^[A-Z]\d{3,4}[A-Z]?$/.test(code)) return "hcpcs";
+  return "unknown";
+}
+
+// ---------------------------------------------------------------------------
+// SSP Parsing
+// ---------------------------------------------------------------------------
+
+interface SSPComponent {
+  code: string;
+  totalCount: number;
+  association: number;
+  resolvedFrom: string[];
+  codeType: CodeType;
+}
+
+interface SSPEpisode {
+  principalCode: string;
+  principalCodeType: CodeType;
+  components: SSPComponent[];
+  facilityComponents: SSPComponent[]; // association >= 0.4
+  optionalComponents: SSPComponent[]; // 0.3 <= association < 0.4
+}
+
+function parseSSPFile(filePath: string, principalCode: string): SSPEpisode {
+  const content = readFileSync(filePath, "utf-8");
+  const lines = content.trim().split("\n");
+  const components: SSPComponent[] = [];
+
+  // Skip header
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) continue;
+
+    // CSV: cpt,total_count,association,resolveFroms
+    const parts = line.split(",");
+    if (parts.length < 3) continue;
+
+    const code = parts[0].trim();
+    const totalCount = parseInt(parts[1], 10) || 0;
+    const association = parseFloat(parts[2]) || 0;
+    const resolvedFrom = parts[3]
+      ? parts[3]
+          .split("|")
+          .map((c) => c.trim())
+          .filter(Boolean)
+      : [];
+
+    components.push({
+      code,
+      totalCount,
+      association,
+      resolvedFrom,
+      codeType: classifyCode(code),
+    });
+  }
+
+  // Classify into tiers based on Turquoise thresholds
+  const facilityComponents = components.filter(
+    (c) => c.association >= FACILITY_THRESHOLD
+  );
+  const optionalComponents = components.filter(
+    (c) => c.association >= OPTIONAL_LOWER && c.association < FACILITY_THRESHOLD
+  );
+
+  return {
+    principalCode,
+    principalCodeType: classifyCode(principalCode),
+    components,
+    facilityComponents,
+    optionalComponents,
+  };
+}
+
+function loadAllSSPEpisodes(): SSPEpisode[] {
+  const files = readdirSync(SSP_DIR).filter((f) => f.endsWith(".csv"));
+  const episodes: SSPEpisode[] = [];
+
+  for (const file of files) {
+    const principalCode = file.replace("beta_sorted_", "").replace(".csv", "");
+    try {
+      episodes.push(parseSSPFile(join(SSP_DIR, file), principalCode));
+    } catch {
+      console.warn(`  Warning: Could not parse ${file}`);
+    }
+  }
+
+  return episodes;
+}
+
+// ---------------------------------------------------------------------------
+// Layer 1: SSP vs Code List
+// ---------------------------------------------------------------------------
+
+interface Layer1Results {
+  ourCodes: Set<string>;
+  sspPrincipalCodes: Set<string>;
+  overlap: Set<string>;
+  sspOnly: Set<string>;
+  ourOnly: Set<string>;
+  overlapByCodeType: Map<CodeType, number>;
+  sspPrincipalByType: Map<CodeType, number>;
+}
+
+function analyzeLayer1(
+  episodes: SSPEpisode[],
+  ourCodes: Set<string>
+): Layer1Results {
+  const sspPrincipalCodes = new Set(episodes.map((e) => e.principalCode));
+  const overlap = new Set(
+    [...ourCodes].filter((c) => sspPrincipalCodes.has(c))
+  );
+  const sspOnly = new Set(
+    [...sspPrincipalCodes].filter((c) => !ourCodes.has(c))
+  );
+  const ourOnly = new Set(
+    [...ourCodes].filter((c) => !sspPrincipalCodes.has(c))
+  );
+
+  const overlapByCodeType = new Map<CodeType, number>();
+  for (const code of overlap) {
+    const ct = classifyCode(code);
+    overlapByCodeType.set(ct, (overlapByCodeType.get(ct) || 0) + 1);
+  }
+
+  const sspPrincipalByType = new Map<CodeType, number>();
+  for (const ep of episodes) {
+    sspPrincipalByType.set(
+      ep.principalCodeType,
+      (sspPrincipalByType.get(ep.principalCodeType) || 0) + 1
+    );
+  }
+
+  return {
+    ourCodes,
+    sspPrincipalCodes,
+    overlap,
+    sspOnly,
+    ourOnly,
+    overlapByCodeType,
+    sspPrincipalByType,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Layer 2: SSP Component Codes vs Supabase Charges
+// ---------------------------------------------------------------------------
+
+interface EpisodeCoverage {
+  principalCode: string;
+  facilityComponents: number;
+  cptHcpcsCodes: string[]; // billable codes (not revenue)
+  priceableCodes: string[]; // codes we have charges for
+  missingCodes: string[]; // codes we don't have charges for
+  revenueCodeCount: number; // revenue codes (not in our data model)
+  coverageRatio: number; // priceable / (cptHcpcsCodes count)
+}
+
+interface Layer2Results {
+  episodeCoverage: EpisodeCoverage[];
+  allComponentCodes: Set<string>;
+  allBillableCodes: Set<string>; // CPT + HCPCS only
+  priceableCodes: Set<string>;
+  missingCodes: Set<string>;
+  overallCoverageRatio: number;
+  medianCoverageRatio: number;
+  episodesWithFullCoverage: number;
+  episodesWithZeroCoverage: number;
+}
+
+async function analyzeLayer2(
+  episodes: SSPEpisode[],
+  overlapEpisodes: SSPEpisode[]
+): Promise<Layer2Results> {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !supabaseKey) {
+    throw new Error(
+      "Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY"
+    );
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseKey);
+
+  // Collect all unique billable component codes from overlap episodes
+  // (facility-tier only — association >= 0.4)
+  const allComponentCodes = new Set<string>();
+  const allBillableCodes = new Set<string>();
+
+  for (const ep of overlapEpisodes) {
+    for (const comp of ep.facilityComponents) {
+      allComponentCodes.add(comp.code);
+      const ct = comp.codeType;
+      if (BILLABLE_CODE_TYPES.includes(ct)) {
+        allBillableCodes.add(comp.code);
+      }
+    }
+  }
+
+  console.log(
+    `  Checking ${allBillableCodes.size} unique billable component codes against Supabase...`
+  );
+
+  // Use the existing audit_code_coverage RPC — pushes the work to Postgres
+  const codesArray = [...allBillableCodes];
+  const priceableCodes = new Set<string>();
+  const BATCH_SIZE = 500;
+
+  for (let i = 0; i < codesArray.length; i += BATCH_SIZE) {
+    const batch = codesArray.slice(i, i + BATCH_SIZE);
+
+    const { data, error } = await supabase.rpc("audit_code_coverage", {
+      p_codes: batch,
+    });
+
+    if (error) {
+      console.error("  Supabase RPC error:", error.message);
+      continue;
+    }
+
+    if (data) {
+      for (const row of data as { code: string; match_count: number }[]) {
+        if (row.match_count > 0) {
+          priceableCodes.add(row.code);
+        }
+      }
+    }
+  }
+
+  console.log(
+    `  Found charges for ${priceableCodes.size}/${allBillableCodes.size} component codes`
+  );
+
+  // Per-episode coverage
+  const episodeCoverage: EpisodeCoverage[] = [];
+  for (const ep of overlapEpisodes) {
+    const cptHcpcsCodes = ep.facilityComponents
+      .filter((c) => BILLABLE_CODE_TYPES.includes(c.codeType))
+      .map((c) => c.code);
+    const priceable = cptHcpcsCodes.filter((c) => priceableCodes.has(c));
+    const missing = cptHcpcsCodes.filter((c) => !priceableCodes.has(c));
+    const revenueCodeCount = ep.facilityComponents.filter(
+      (c) => c.codeType === "revenue_code"
+    ).length;
+
+    episodeCoverage.push({
+      principalCode: ep.principalCode,
+      facilityComponents: ep.facilityComponents.length,
+      cptHcpcsCodes,
+      priceableCodes: priceable,
+      missingCodes: missing,
+      revenueCodeCount,
+      coverageRatio:
+        cptHcpcsCodes.length > 0 ? priceable.length / cptHcpcsCodes.length : 0,
+    });
+  }
+
+  const ratios = episodeCoverage
+    .map((e) => e.coverageRatio)
+    .sort((a, b) => a - b);
+  const missingCodes = new Set(
+    [...allBillableCodes].filter((c) => !priceableCodes.has(c))
+  );
+
+  return {
+    episodeCoverage,
+    allComponentCodes,
+    allBillableCodes,
+    priceableCodes,
+    missingCodes,
+    overallCoverageRatio:
+      allBillableCodes.size > 0
+        ? priceableCodes.size / allBillableCodes.size
+        : 0,
+    medianCoverageRatio:
+      ratios.length > 0 ? ratios[Math.floor(ratios.length / 2)] : 0,
+    episodesWithFullCoverage: episodeCoverage.filter(
+      (e) => e.coverageRatio === 1
+    ).length,
+    episodesWithZeroCoverage: episodeCoverage.filter(
+      (e) => e.coverageRatio === 0
+    ).length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Layer 3: Gap Analysis
+// ---------------------------------------------------------------------------
+
+interface GapCode {
+  code: string;
+  codeType: CodeType;
+  episodeCount: number; // how many SSP episodes reference this code
+  avgAssociation: number;
+  maxAssociation: number;
+}
+
+interface Layer3Results {
+  frequentMissingCodes: GapCode[];
+  codeListExpansionCandidates: GapCode[]; // high-frequency, priceable type
+  structuralGaps: GapCode[]; // revenue codes / types we'll never have
+  totalUniqueComponentCodes: number;
+  componentCodesByType: Map<CodeType, number>;
+}
+
+function analyzeLayer3(
+  episodes: SSPEpisode[],
+  ourCodes: Set<string>
+): Layer3Results {
+  // Build frequency map across ALL episodes (not just overlap)
+  const codeFrequency = new Map<
+    string,
+    { episodes: number; associations: number[]; codeType: CodeType }
+  >();
+
+  for (const ep of episodes) {
+    for (const comp of ep.facilityComponents) {
+      const existing = codeFrequency.get(comp.code) || {
+        episodes: 0,
+        associations: [],
+        codeType: comp.codeType,
+      };
+      existing.episodes++;
+      existing.associations.push(comp.association);
+      codeFrequency.set(comp.code, existing);
+    }
+  }
+
+  // Count by type
+  const componentCodesByType = new Map<CodeType, number>();
+  for (const [, val] of codeFrequency) {
+    componentCodesByType.set(
+      val.codeType,
+      (componentCodesByType.get(val.codeType) || 0) + 1
+    );
+  }
+
+  // Build gap codes
+  const gapCodes: GapCode[] = [];
+  for (const [code, freq] of codeFrequency) {
+    if (!ourCodes.has(code)) {
+      gapCodes.push({
+        code,
+        codeType: freq.codeType,
+        episodeCount: freq.episodes,
+        avgAssociation:
+          freq.associations.reduce((a, b) => a + b, 0) /
+          freq.associations.length,
+        maxAssociation: Math.max(...freq.associations),
+      });
+    }
+  }
+
+  gapCodes.sort((a, b) => b.episodeCount - a.episodeCount);
+
+  // Codes we could potentially add to our import (CPT/HCPCS, not revenue)
+  const expansionCandidates = gapCodes
+    .filter(
+      (g) =>
+        BILLABLE_CODE_TYPES.includes(g.codeType) &&
+        g.episodeCount >= 10 &&
+        g.avgAssociation >= 0.3
+    )
+    .slice(0, 100);
+
+  // Structural gaps (revenue codes, C-codes — hospital internal, won't have standalone charges)
+  const structuralGaps = gapCodes.filter(
+    (g) => g.codeType === "revenue_code" || g.codeType === "c_code"
+  );
+
+  return {
+    frequentMissingCodes: gapCodes.slice(0, 50),
+    codeListExpansionCandidates: expansionCandidates,
+    structuralGaps,
+    totalUniqueComponentCodes: codeFrequency.size,
+    componentCodesByType,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Data Model Analysis
+// ---------------------------------------------------------------------------
+
+interface DataModelInsights {
+  componentCountDistribution: {
+    min: number;
+    max: number;
+    median: number;
+    p25: number;
+    p75: number;
+    avg: number;
+  };
+  facilityComponentDistribution: {
+    min: number;
+    max: number;
+    median: number;
+    avg: number;
+  };
+  associationDistribution: {
+    highConfidence: number; // >= 0.7
+    moderate: number; // 0.4-0.7
+    low: number; // 0.3-0.4
+    rare: number; // < 0.3
+  };
+  codeTypeMix: Map<CodeType, { count: number; avgAssociation: number }>;
+}
+
+function analyzeDataModel(episodes: SSPEpisode[]): DataModelInsights {
+  const totalComponents = episodes
+    .map((e) => e.components.length)
+    .sort((a, b) => a - b);
+  const facilityComponents = episodes
+    .map((e) => e.facilityComponents.length)
+    .sort((a, b) => a - b);
+
+  let highConf = 0,
+    moderate = 0,
+    low = 0,
+    rare = 0;
+  const codeTypeMix = new Map<
+    CodeType,
+    { count: number; totalAssoc: number }
+  >();
+
+  for (const ep of episodes) {
+    for (const comp of ep.components) {
+      if (comp.association >= 0.7) highConf++;
+      else if (comp.association >= 0.4) moderate++;
+      else if (comp.association >= 0.3) low++;
+      else rare++;
+
+      const existing = codeTypeMix.get(comp.codeType) || {
+        count: 0,
+        totalAssoc: 0,
+      };
+      existing.count++;
+      existing.totalAssoc += comp.association;
+      codeTypeMix.set(comp.codeType, existing);
+    }
+  }
+
+  const percentile = (arr: number[], p: number) =>
+    arr[Math.floor(arr.length * p)] ?? 0;
+
+  return {
+    componentCountDistribution: {
+      min: totalComponents[0] ?? 0,
+      max: totalComponents[totalComponents.length - 1] ?? 0,
+      median: percentile(totalComponents, 0.5),
+      p25: percentile(totalComponents, 0.25),
+      p75: percentile(totalComponents, 0.75),
+      avg:
+        totalComponents.length > 0
+          ? totalComponents.reduce((a, b) => a + b, 0) / totalComponents.length
+          : 0,
+    },
+    facilityComponentDistribution: {
+      min: facilityComponents[0] ?? 0,
+      max: facilityComponents[facilityComponents.length - 1] ?? 0,
+      median: percentile(facilityComponents, 0.5),
+      avg:
+        facilityComponents.length > 0
+          ? facilityComponents.reduce((a, b) => a + b, 0) /
+            facilityComponents.length
+          : 0,
+    },
+    associationDistribution: {
+      highConfidence: highConf,
+      moderate,
+      low,
+      rare,
+    },
+    codeTypeMix: new Map(
+      [...codeTypeMix.entries()].map(([k, v]) => [
+        k,
+        { count: v.count, avgAssociation: v.totalAssoc / v.count },
+      ])
+    ),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Output
+// ---------------------------------------------------------------------------
+
+function printResults(
+  layer1: Layer1Results,
+  layer2: Layer2Results,
+  layer3: Layer3Results,
+  dataModel: DataModelInsights,
+  totalEpisodes: number
+) {
+  console.log("\n" + "=".repeat(70));
+  console.log(
+    "SSP DATASET ANALYSIS — Turquoise Health Standard Service Packages"
+  );
+  console.log("=".repeat(70));
+
+  // --- Layer 1 ---
+  console.log("\n--- LAYER 1: SSP Principal Codes vs Our Code List ---\n");
+  console.log(`Our codes:            ${layer1.ourCodes.size}`);
+  console.log(`SSP principal codes:  ${layer1.sspPrincipalCodes.size}`);
+  console.log(
+    `Overlap:              ${layer1.overlap.size} (${((layer1.overlap.size / layer1.ourCodes.size) * 100).toFixed(1)}% of ours, ${((layer1.overlap.size / layer1.sspPrincipalCodes.size) * 100).toFixed(1)}% of SSP)`
+  );
+  console.log(`SSP-only:             ${layer1.sspOnly.size}`);
+  console.log(`Our-only:             ${layer1.ourOnly.size}`);
+
+  console.log("\nSSP principal code types:");
+  for (const [type, count] of [...layer1.sspPrincipalByType.entries()].sort(
+    (a, b) => b[1] - a[1]
+  )) {
+    console.log(`  ${type.padEnd(15)} ${count}`);
+  }
+
+  console.log("\nOverlap by code type:");
+  for (const [type, count] of [...layer1.overlapByCodeType.entries()].sort(
+    (a, b) => b[1] - a[1]
+  )) {
+    console.log(`  ${type.padEnd(15)} ${count}`);
+  }
+
+  console.log("\nSample overlap codes (first 20):");
+  console.log(`  ${[...layer1.overlap].sort().slice(0, 20).join(", ")}`);
+
+  // --- Layer 2 ---
+  console.log("\n--- LAYER 2: Component Code Charge Coverage (Supabase) ---\n");
+  console.log(
+    `Unique component codes (facility-tier, overlap episodes): ${layer2.allComponentCodes.size}`
+  );
+  console.log(
+    `Billable codes (CPT/HCPCS):                               ${layer2.allBillableCodes.size}`
+  );
+  console.log(
+    `Codes with Supabase charges:                              ${layer2.priceableCodes.size}`
+  );
+  console.log(
+    `Missing from Supabase:                                    ${layer2.missingCodes.size}`
+  );
+  console.log(
+    `Overall coverage ratio:                                   ${(layer2.overallCoverageRatio * 100).toFixed(1)}%`
+  );
+  console.log(
+    `Median per-episode coverage:                              ${(layer2.medianCoverageRatio * 100).toFixed(1)}%`
+  );
+  console.log(
+    `Episodes with 100% coverage:                              ${layer2.episodesWithFullCoverage}/${layer2.episodeCoverage.length}`
+  );
+  console.log(
+    `Episodes with 0% coverage:                                ${layer2.episodesWithZeroCoverage}/${layer2.episodeCoverage.length}`
+  );
+
+  // Show per-episode breakdown for top 15 overlap episodes
+  console.log("\nPer-episode coverage (top 15 by component count):");
+  const sortedEpisodes = [...layer2.episodeCoverage].sort(
+    (a, b) => b.facilityComponents - a.facilityComponents
+  );
+  for (const ep of sortedEpisodes.slice(0, 15)) {
+    console.log(
+      `  ${ep.principalCode.padEnd(8)} ${ep.cptHcpcsCodes.length} billable, ${ep.priceableCodes.length} priceable (${(ep.coverageRatio * 100).toFixed(0)}%), ${ep.revenueCodeCount} rev codes`
+    );
+  }
+
+  // --- Layer 3 ---
+  console.log("\n--- LAYER 3: Gap Analysis ---\n");
+  console.log(
+    `Total unique component codes across all SSPs: ${layer3.totalUniqueComponentCodes}`
+  );
+
+  console.log("\nComponent codes by type:");
+  for (const [type, count] of [...layer3.componentCodesByType.entries()].sort(
+    (a, b) => b[1] - a[1]
+  )) {
+    console.log(`  ${type.padEnd(15)} ${count}`);
+  }
+
+  console.log(
+    `\nCode list expansion candidates (CPT/HCPCS, >=10 episodes, avg assoc>=0.3): ${layer3.codeListExpansionCandidates.length}`
+  );
+  console.log("Top 20:");
+  for (const gap of layer3.codeListExpansionCandidates.slice(0, 20)) {
+    console.log(
+      `  ${gap.code.padEnd(8)} ${gap.codeType.padEnd(10)} ${gap.episodeCount} episodes, avg assoc ${gap.avgAssociation.toFixed(2)}`
+    );
+  }
+
+  console.log(
+    `\nStructural gaps (revenue/C-codes — not in MRF data model): ${layer3.structuralGaps.length}`
+  );
+  console.log("Top 10 most common revenue codes:");
+  const topRevCodes = layer3.structuralGaps
+    .filter((g) => g.codeType === "revenue_code")
+    .slice(0, 10);
+  for (const gap of topRevCodes) {
+    console.log(
+      `  ${gap.code.padEnd(8)} ${gap.episodeCount} episodes, avg assoc ${gap.avgAssociation.toFixed(2)}`
+    );
+  }
+
+  // --- Data Model ---
+  console.log("\n--- DATA MODEL INSIGHTS ---\n");
+  console.log("Component count distribution (all components, all episodes):");
+  const d = dataModel.componentCountDistribution;
+  console.log(
+    `  Min: ${d.min}, P25: ${d.p25}, Median: ${d.median}, P75: ${d.p75}, Max: ${d.max}, Avg: ${d.avg.toFixed(0)}`
+  );
+
+  console.log("\nFacility-tier component count (association >= 0.4):");
+  const fd = dataModel.facilityComponentDistribution;
+  console.log(
+    `  Min: ${fd.min}, Median: ${fd.median}, Max: ${fd.max}, Avg: ${fd.avg.toFixed(0)}`
+  );
+
+  console.log("\nAssociation score distribution:");
+  const ad = dataModel.associationDistribution;
+  const totalAssoc = ad.highConfidence + ad.moderate + ad.low + ad.rare;
+  console.log(
+    `  High (>=0.7):   ${ad.highConfidence} (${((ad.highConfidence / totalAssoc) * 100).toFixed(1)}%)`
+  );
+  console.log(
+    `  Moderate (0.4-0.7): ${ad.moderate} (${((ad.moderate / totalAssoc) * 100).toFixed(1)}%)`
+  );
+  console.log(
+    `  Low (0.3-0.4):  ${ad.low} (${((ad.low / totalAssoc) * 100).toFixed(1)}%)`
+  );
+  console.log(
+    `  Rare (<0.3):    ${ad.rare} (${((ad.rare / totalAssoc) * 100).toFixed(1)}%)`
+  );
+
+  console.log("\nCode type mix in components:");
+  for (const [type, stats] of [...dataModel.codeTypeMix.entries()].sort(
+    (a, b) => b[1].count - a[1].count
+  )) {
+    console.log(
+      `  ${type.padEnd(15)} ${stats.count} occurrences, avg assoc ${stats.avgAssociation.toFixed(2)}`
+    );
+  }
+
+  console.log("\n" + "=".repeat(70));
+  console.log("ANALYSIS COMPLETE");
+  console.log("=".repeat(70));
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  console.log("Loading SSP dataset...");
+  const episodes = loadAllSSPEpisodes();
+  console.log(`  Loaded ${episodes.length} SSP episodes from ${SSP_DIR}`);
+
+  console.log("Loading ClearCost code list...");
+  const ourCodesArray: string[] = JSON.parse(
+    readFileSync(CODE_LIST_PATH, "utf-8")
+  );
+  const ourCodes = new Set(ourCodesArray);
+  console.log(`  Loaded ${ourCodes.size} codes from ${CODE_LIST_PATH}`);
+
+  console.log("\nRunning Layer 1: SSP vs Code List...");
+  const layer1 = analyzeLayer1(episodes, ourCodes);
+
+  // Filter to overlap episodes for Layer 2
+  const overlapEpisodes = episodes.filter((ep) =>
+    ourCodes.has(ep.principalCode)
+  );
+  console.log(
+    `\nRunning Layer 2: Component coverage (${overlapEpisodes.length} overlap episodes)...`
+  );
+  const layer2 = await analyzeLayer2(episodes, overlapEpisodes);
+
+  console.log("\nRunning Layer 3: Gap analysis...");
+  const layer3 = analyzeLayer3(episodes, ourCodes);
+
+  console.log("Analyzing data model implications...");
+  const dataModel = analyzeDataModel(episodes);
+
+  printResults(layer1, layer2, layer3, dataModel, episodes.length);
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Analyzed Turquoise Health SSP (Standard Service Packages) dataset — 2,948 episode definitions built from 2.7B real claims
- **120 of our 1,002 codes** have SSP episode definitions (complex surgical procedures)
- **68% of component codes** already have charge data in Supabase; median episode is 75% priceable
- Identified 48 expansion candidate codes (J-codes, pathology, sedation) for targeted import
- Proposed `episode_definitions` / `episode_components` schema for #63

Closes #100

## Files
- `scripts/ssp-analysis.ts` — reusable analysis script (kept for #92)
- `docs/ssp-research.md` — full findings document (7 sections: overview, schema, coverage, data model, feasibility, code list implications, next steps)

## Test plan
- [x] `npx tsx --env-file=.env.local scripts/ssp-analysis.ts` runs successfully
- [x] `npm run lint` passes (0 errors)
- [x] Research doc contains all 7 required sections with quantitative findings
- [x] Supabase queries return meaningful results (158/232 codes matched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)