### PR TITLE
Extract shared haversine utility from MapView and lookup

### DIFF
--- a/components/MapView.tsx
+++ b/components/MapView.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { setOptions, importLibrary } from "@googlemaps/js-api-loader";
 import type { ChargeResult } from "@/types";
 import { getDisplayPrice, formatDisplayPrice } from "@/lib/format";
+import { haversineMiles } from "@/lib/geo";
 
 interface MapViewProps {
   results: ChargeResult[];
@@ -78,30 +79,6 @@ const FIT_MARKER_LIMIT = 24;
 const FIT_RADIUS_MILES = 30;
 const FIT_MIN_ZOOM = 10;
 const FIT_MAX_ZOOM = 13;
-
-function toRadians(degrees: number): number {
-  return degrees * (Math.PI / 180);
-}
-
-function haversineMiles(
-  originLat: number,
-  originLng: number,
-  targetLat: number,
-  targetLng: number
-): number {
-  const earthRadiusMiles = 3958.8;
-  const latDelta = toRadians(targetLat - originLat);
-  const lngDelta = toRadians(targetLng - originLng);
-
-  const a =
-    Math.sin(latDelta / 2) ** 2 +
-    Math.cos(toRadians(originLat)) *
-      Math.cos(toRadians(targetLat)) *
-      Math.sin(lngDelta / 2) ** 2;
-  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-
-  return earthRadiusMiles * c;
-}
 
 export function MapView({
   results,

--- a/lib/cpt/lookup.ts
+++ b/lib/cpt/lookup.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import { milesToKm, kmToMiles } from "@/lib/units";
+import { haversineMiles } from "@/lib/geo";
 // @ts-expect-error zipcodes has no bundled TypeScript declarations.
 import zipcodes from "zipcodes";
 import type {
@@ -138,30 +139,6 @@ export function createLookupDiagnostics(): LookupDiagnostics {
     fallbackExhausted: false,
     stageSummaries: [],
   };
-}
-
-function toRadians(degrees: number): number {
-  return degrees * (Math.PI / 180);
-}
-
-function haversineMiles(
-  originLat: number,
-  originLng: number,
-  targetLat: number,
-  targetLng: number
-): number {
-  const earthRadiusMiles = 3958.8;
-  const latDelta = toRadians(targetLat - originLat);
-  const lngDelta = toRadians(targetLng - originLng);
-
-  const a =
-    Math.sin(latDelta / 2) ** 2 +
-    Math.cos(toRadians(originLat)) *
-      Math.cos(toRadians(targetLat)) *
-      Math.sin(lngDelta / 2) ** 2;
-
-  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-  return earthRadiusMiles * c;
 }
 
 function escapeRegex(value: string): string {

--- a/lib/geo.ts
+++ b/lib/geo.ts
@@ -1,0 +1,23 @@
+function toRadians(degrees: number): number {
+  return degrees * (Math.PI / 180);
+}
+
+export function haversineMiles(
+  originLat: number,
+  originLng: number,
+  targetLat: number,
+  targetLng: number
+): number {
+  const earthRadiusMiles = 3958.8;
+  const latDelta = toRadians(targetLat - originLat);
+  const lngDelta = toRadians(targetLng - originLng);
+
+  const a =
+    Math.sin(latDelta / 2) ** 2 +
+    Math.cos(toRadians(originLat)) *
+      Math.cos(toRadians(targetLat)) *
+      Math.sin(lngDelta / 2) ** 2;
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+  return earthRadiusMiles * c;
+}


### PR DESCRIPTION
## Summary
- Consolidate identical `toRadians()` and `haversineMiles()` from `components/MapView.tsx` and `lib/cpt/lookup.ts` into shared `lib/geo.ts`
- Net -23 lines of duplicated code, single source of truth for geo distance calculation
- `toRadians` kept as private helper (not exported) — only `haversineMiles` is public API

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes (0 errors, 1 pre-existing warning)
- [x] Prettier format check passes (lint-staged ran in pre-commit hook)
- [x] Manual smoke: search → results render with correct distances
- [x] Manual smoke: map view displays markers correctly

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)