### PR TITLE
Unify duplicate results iteration in MapView markers effect

### DIFF
--- a/components/MapView.tsx
+++ b/components/MapView.tsx
@@ -145,23 +145,21 @@ export function MapView({
 
     const markers: google.maps.Marker[] = [];
     let fitListener: google.maps.MapsEventListener | null = null;
-    const positionedResults = results.flatMap((result) => {
+    const positionedResults = results.flatMap((result, index) => {
       const { lat, lng } = result.provider;
       if (lat == null || lng == null) return [];
-      return [{ result, lat, lng }];
+      return [{ result, lat, lng, index }];
     });
 
-    results.forEach((result, i) => {
-      if (result.provider.lat == null || result.provider.lng == null) return;
-
-      const position = { lat: result.provider.lat, lng: result.provider.lng };
+    positionedResults.forEach(({ result, lat, lng, index }) => {
+      const position = { lat, lng };
 
       const isSelected = result.id === selectedResultId;
       const marker = new google.maps.Marker({
         position,
         map,
         label: {
-          text: `${i + 1}`,
+          text: `${index + 1}`,
           color: "white",
           fontSize: isSelected ? "13px" : "11px",
           fontWeight: "600",
@@ -174,7 +172,7 @@ export function MapView({
           strokeColor: isSelected ? "#B45309" : "#115E59",
           strokeWeight: isSelected ? 3 : 2,
         },
-        zIndex: isSelected ? 1000 : i,
+        zIndex: isSelected ? 1000 : index,
       });
 
       const infoWindow = new google.maps.InfoWindow({


### PR DESCRIPTION
## Summary
- Drive marker creation from `positionedResults` instead of raw `results`, eliminating redundant null-coordinate guard and duplicate traversal
- Carry original `results` array index through so marker label numbers continue to match list position
- Net -2 lines, cleaner single-pass architecture

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes (0 errors, 1 pre-existing warning)
- [x] Prettier format check passes (lint-staged ran in pre-commit hook)
- [ ] Manual smoke: search → markers render on map with correct numbering
- [ ] Manual smoke: click marker → info window opens, result card highlights

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)