### PR TITLE
Aggregate same-provider charges into single result card

### DIFF
--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -17,6 +17,7 @@ import {
 } from "@/lib/cpt/cache";
 import { normalizeCodeType } from "@/lib/cpt/body-site-laterality-constants";
 import { lookupMedicareBenchmarks } from "@/lib/cpt/medicare";
+import { groupResultsByProvider } from "@/lib/cpt/group-results";
 import { getDisplayPrice } from "@/lib/format";
 import { handleApiError } from "@/lib/api-helpers";
 import type {
@@ -269,13 +270,14 @@ export async function POST(request: NextRequest) {
       });
 
       const enriched = await enrichWithMedicareBenchmarks(results);
+      const grouped = groupResultsByProvider(enriched);
       return respond({
         query: queryText,
         interpretation: providedInterpretation || "",
         pricingPlan,
         cptCodes: [],
-        results: enriched,
-        totalResults: enriched.length,
+        results: grouped,
+        totalResults: grouped.length,
       });
     }
 
@@ -318,13 +320,14 @@ export async function POST(request: NextRequest) {
       });
 
       const enriched = await enrichWithMedicareBenchmarks(results);
+      const grouped = groupResultsByProvider(enriched);
       return respond({
         query: queryText,
         interpretation: providedInterpretation || "",
         pricingPlan,
         cptCodes: [],
-        results: enriched,
-        totalResults: enriched.length,
+        results: grouped,
+        totalResults: grouped.length,
       });
     }
 
@@ -393,13 +396,14 @@ export async function POST(request: NextRequest) {
     });
 
     const enriched = await enrichWithMedicareBenchmarks(results);
+    const grouped = groupResultsByProvider(enriched);
     return respond({
       query: queryText,
       interpretation: translated.interpretation,
       pricingPlan,
       cptCodes: translated.codes,
-      results: enriched,
-      totalResults: enriched.length,
+      results: grouped,
+      totalResults: grouped.length,
     });
   } catch (error) {
     const response = handleApiError(error, "POST /api/search");

--- a/components/ResultCard.tsx
+++ b/components/ResultCard.tsx
@@ -8,7 +8,7 @@ import {
   getDisplayPrice,
   formatDisplayPrice,
 } from "@/lib/format";
-import type { ChargeResult } from "@/types";
+import type { ChargeResult, GroupedChargeResult } from "@/types";
 import { InfoCircleIcon } from "./InfoCircleIcon";
 import { Tooltip } from "./Tooltip";
 
@@ -42,6 +42,14 @@ function formatAdderPriceRange(
   return "N/A";
 }
 
+function billingClassLabel(bc: string | undefined): string {
+  const normalized = bc?.toLowerCase();
+  if (normalized === "facility") return "Facility fee";
+  if (normalized === "professional") return "Professional fee";
+  if (normalized === "both") return "Global fee";
+  return "Full charge";
+}
+
 export function ResultCard({
   result,
   rank,
@@ -54,6 +62,11 @@ export function ResultCard({
   const distance = formatDistance(result.distanceMiles);
   const lastUpdated = formatDate(result.lastUpdated);
   const displayPrice = getDisplayPrice(result);
+
+  const isGrouped = "chargeVariants" in result;
+  const grouped = isGrouped ? (result as GroupedChargeResult) : undefined;
+  const variants = grouped?.chargeVariants;
+  const hasVariants = (grouped?.variantCount ?? 1) > 1;
 
   const resultCode = result.cpt || result.hcpcs || result.msDrg;
   const canonicalDescription = resultCode
@@ -70,14 +83,17 @@ export function ResultCard({
     .filter(notNull)
     .join(", ");
 
-  const billingClassCallout = (() => {
-    const bc = result.billingClass?.toLowerCase();
-    if (bc === "facility")
-      return "Facility fee only — professional fees may apply separately";
-    if (bc === "professional")
-      return "Professional fee only — facility charges may apply separately";
-    return null;
-  })();
+  // Suppress single-charge billing class callout when variant breakdown is shown
+  const billingClassCallout = hasVariants
+    ? null
+    : (() => {
+        const bc = result.billingClass?.toLowerCase();
+        if (bc === "facility")
+          return "Facility fee only — professional fees may apply separately";
+        if (bc === "professional")
+          return "Professional fee only — facility charges may apply separately";
+        return null;
+      })();
 
   const priceColor =
     displayPrice.type === "cash"
@@ -366,6 +382,87 @@ export function ResultCard({
                   >
                     <InfoCircleIcon className="w-3.5 h-3.5 shrink-0 mt-0.5" />
                     <span className="text-xs">{billingClassCallout}</span>
+                  </div>
+                )}
+
+                {/* Price variants breakdown */}
+                {hasVariants && variants && (
+                  <div
+                    className="mt-3 p-3 rounded-lg border"
+                    style={{
+                      background: "var(--cc-surface-alt)",
+                      borderColor: "var(--cc-border)",
+                    }}
+                  >
+                    <p
+                      className="text-xs font-semibold"
+                      style={{ color: "var(--cc-text-secondary)" }}
+                    >
+                      Price variants at this facility
+                    </p>
+                    <div className="mt-2 space-y-1">
+                      {variants.map((v) => {
+                        const vp = getDisplayPrice(v as ChargeResult);
+                        const isPrimary = v.id === result.id;
+                        return (
+                          <div
+                            key={v.id}
+                            className="flex items-center gap-2 py-1 px-2 rounded"
+                            style={{
+                              borderLeft: isPrimary
+                                ? "2px solid var(--cc-primary)"
+                                : "2px solid transparent",
+                              background: isPrimary
+                                ? "var(--cc-primary-light)"
+                                : undefined,
+                            }}
+                          >
+                            <span
+                              className="text-[11px] font-medium px-1.5 py-0.5 rounded shrink-0"
+                              style={{
+                                background: "var(--cc-surface)",
+                                color: "var(--cc-text-secondary)",
+                                border: "1px solid var(--cc-border)",
+                              }}
+                            >
+                              {billingClassLabel(v.billingClass)}
+                            </span>
+                            <span
+                              className="text-xs truncate min-w-0"
+                              style={{
+                                color: isPrimary
+                                  ? "var(--cc-text)"
+                                  : "var(--cc-text-tertiary)",
+                              }}
+                              title={v.description}
+                            >
+                              {v.description || "—"}
+                            </span>
+                            <span className="flex-1" />
+                            <span
+                              className="text-xs font-semibold shrink-0"
+                              style={{
+                                color: isPrimary
+                                  ? "var(--cc-primary)"
+                                  : "var(--cc-text-secondary)",
+                              }}
+                            >
+                              {formatDisplayPrice(vp)}
+                            </span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                    <div
+                      className="flex items-start gap-1 mt-2"
+                      style={{ color: "var(--cc-text-tertiary)" }}
+                    >
+                      <InfoCircleIcon className="w-3 h-3 shrink-0 mt-0.5" />
+                      <span className="text-[11px]">
+                        Different billing contexts for the same procedure. The
+                        highlighted row is shown above.
+                      </span>
+                    </div>
                   </div>
                 )}
 

--- a/lib/cpt/group-results.ts
+++ b/lib/cpt/group-results.ts
@@ -1,0 +1,92 @@
+import type { ChargeResult, ChargeVariant, GroupedChargeResult } from "@/types";
+
+function billingClassTier(bc: string | undefined): number {
+  const normalized = bc?.toLowerCase();
+  if (!normalized || normalized === "both") return 0; // global/most complete
+  if (normalized === "facility") return 1;
+  if (normalized === "professional") return 2;
+  return 0; // unknown treated as potentially complete
+}
+
+function priceTypeTier(result: ChargeResult): number {
+  if (result.cashPrice != null) return 0;
+  if (result.avgNegotiatedRate != null) return 1;
+  if (result.grossCharge != null) return 2;
+  return 3; // no price
+}
+
+function bestPrice(result: ChargeResult): number {
+  return (
+    result.cashPrice ??
+    result.avgNegotiatedRate ??
+    result.grossCharge ??
+    Infinity
+  );
+}
+
+function selectPrimary(charges: ChargeResult[]): ChargeResult {
+  return charges.reduce((best, cur) => {
+    const tierDiff =
+      billingClassTier(best.billingClass) - billingClassTier(cur.billingClass);
+    if (tierDiff !== 0) return tierDiff < 0 ? best : cur;
+
+    const priceTierDiff = priceTypeTier(best) - priceTypeTier(cur);
+    if (priceTierDiff !== 0) return priceTierDiff < 0 ? best : cur;
+
+    return bestPrice(best) <= bestPrice(cur) ? best : cur;
+  });
+}
+
+function toVariant(result: ChargeResult): ChargeVariant {
+  return {
+    id: result.id,
+    description: result.description,
+    billingClass: result.billingClass,
+    setting: result.setting,
+    laterality: result.laterality,
+    bodySite: result.bodySite,
+    cashPrice: result.cashPrice,
+    grossCharge: result.grossCharge,
+    avgNegotiatedRate: result.avgNegotiatedRate,
+    minPrice: result.minPrice,
+    maxPrice: result.maxPrice,
+    payerCount: result.payerCount,
+    isDiscounted: result.isDiscounted,
+  };
+}
+
+function groupingKey(result: ChargeResult): string {
+  const code =
+    result.cpt || result.hcpcs || result.msDrg || result.description || "";
+  return `${result.provider.id}::${code}`;
+}
+
+export function groupResultsByProvider(
+  results: ChargeResult[]
+): GroupedChargeResult[] {
+  const groups = new Map<string, ChargeResult[]>();
+
+  for (const result of results) {
+    // Pass through encounter-first cards ungrouped — already one-per-provider
+    const key = result.id.includes("::encounter")
+      ? `solo::${result.id}`
+      : groupingKey(result);
+
+    const existing = groups.get(key);
+    if (existing) {
+      existing.push(result);
+    } else {
+      groups.set(key, [result]);
+    }
+  }
+
+  return Array.from(groups.values(), (charges) => {
+    const primary = charges.length === 1 ? charges[0] : selectPrimary(charges);
+    const variants = charges.map(toVariant);
+    return {
+      ...primary,
+      chargeVariants: variants,
+      variantCount: variants.length,
+    };
+  });
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -156,6 +156,29 @@ export interface ChargeResult {
   medicareMultiplierSource?: "cash" | "insured" | "gross";
 }
 
+// -- Charge Variant (lightweight subset for grouped display) --
+export interface ChargeVariant {
+  id: string;
+  description?: string;
+  billingClass?: string;
+  setting?: ChargeSetting;
+  laterality?: Laterality;
+  bodySite?: BodySite;
+  cashPrice?: number;
+  grossCharge?: number;
+  avgNegotiatedRate?: number;
+  minPrice?: number;
+  maxPrice?: number;
+  payerCount?: number;
+  isDiscounted?: boolean;
+}
+
+// -- Grouped Charge Result (multiple charges at same provider collapsed into one card) --
+export interface GroupedChargeResult extends ChargeResult {
+  chargeVariants: ChargeVariant[];
+  variantCount: number;
+}
+
 // -- Medicare Benchmark (CMS Physician Fee Schedule national rate) --
 export interface MedicareBenchmark {
   code: string;


### PR DESCRIPTION
## Summary

- Groups multiple charge rows for the same provider + billing code into a single result card with an inline variant breakdown
- Selects the most complete charge as the headline price (global fee > facility > professional)
- Fixes map pin stacking — one pin per provider instead of per charge
- Preserves all charge data in an expandable variant section (nothing hidden or deleted)

Closes #63

## Changes

| File | What |
|------|------|
| `types/index.ts` | Add `ChargeVariant` + `GroupedChargeResult` types |
| `lib/cpt/group-results.ts` | New module — `groupResultsByProvider()` |
| `app/api/search/route.ts` | Wire grouping into all 3 API response paths |
| `components/ResultCard.tsx` | Variant breakdown UI + billing class callout suppression |

## Test plan

- [ ] Search "EKG" near Miami — HCA Florida Mercy should show 1 card (not 3) with variant breakdown
- [ ] Expand card — verify variant rows show billing class badges and prices
- [ ] Map view — verify one pin per provider (no "3" cluster at same location)
- [ ] Search "knee MRI" — same provider with 2 different CPT codes should still get 2 cards
- [ ] Filter/sort by price and distance still work correctly
- [ ] Single-charge providers look identical to before (no variant section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)