### PR TITLE
Integrate Turquoise SSP episode bundling into search + display

### DIFF
--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -18,6 +18,7 @@ import {
 import { normalizeCodeType } from "@/lib/cpt/body-site-laterality-constants";
 import { lookupMedicareBenchmarks } from "@/lib/cpt/medicare";
 import { groupResultsByProvider } from "@/lib/cpt/group-results";
+import { enrichWithEpisodeEstimates } from "@/lib/cpt/episode";
 import { getDisplayPrice } from "@/lib/format";
 import { handleApiError } from "@/lib/api-helpers";
 import type {
@@ -29,6 +30,19 @@ import type {
 
 const SPARSE_RESULT_THRESHOLD = 3;
 const EXPANDED_RADIUS_MILES = 250;
+
+async function enrichAndGroup(results: ChargeResult[]) {
+  const [withMedicare, withEpisodes] = await Promise.all([
+    enrichWithMedicareBenchmarks(results),
+    enrichWithEpisodeEstimates(results),
+  ]);
+  // Merge: Medicare writes medicareFacilityRate/Multiplier, episodes write episodeEstimate
+  const merged = withMedicare.map((r, i) => ({
+    ...r,
+    episodeEstimate: withEpisodes[i]?.episodeEstimate,
+  }));
+  return groupResultsByProvider(merged);
+}
 
 async function lookupWithAutoExpand(
   params: Parameters<typeof lookupWithPricingPlan>[0]
@@ -272,8 +286,7 @@ export async function POST(request: NextRequest) {
         elapsedMs: Date.now() - startedAt,
       });
 
-      const enriched = await enrichWithMedicareBenchmarks(results);
-      const grouped = groupResultsByProvider(enriched);
+      const grouped = await enrichAndGroup(results);
       return respond({
         query: queryText,
         interpretation: providedInterpretation || "",
@@ -281,6 +294,7 @@ export async function POST(request: NextRequest) {
         cptCodes: [],
         results: grouped,
         totalResults: grouped.length,
+        hasEpisodeEstimates: grouped.some((r) => r.episodeEstimate != null),
       });
     }
 
@@ -322,8 +336,7 @@ export async function POST(request: NextRequest) {
         elapsedMs: Date.now() - startedAt,
       });
 
-      const enriched = await enrichWithMedicareBenchmarks(results);
-      const grouped = groupResultsByProvider(enriched);
+      const grouped = await enrichAndGroup(results);
       return respond({
         query: queryText,
         interpretation: providedInterpretation || "",
@@ -331,6 +344,7 @@ export async function POST(request: NextRequest) {
         cptCodes: [],
         results: grouped,
         totalResults: grouped.length,
+        hasEpisodeEstimates: grouped.some((r) => r.episodeEstimate != null),
       });
     }
 
@@ -398,8 +412,7 @@ export async function POST(request: NextRequest) {
       elapsedMs: Date.now() - startedAt,
     });
 
-    const enriched = await enrichWithMedicareBenchmarks(results);
-    const grouped = groupResultsByProvider(enriched);
+    const grouped = await enrichAndGroup(results);
     return respond({
       query: queryText,
       interpretation: translated.interpretation,
@@ -407,6 +420,7 @@ export async function POST(request: NextRequest) {
       cptCodes: translated.codes,
       results: grouped,
       totalResults: grouped.length,
+      hasEpisodeEstimates: grouped.some((r) => r.episodeEstimate != null),
     });
   } catch (error) {
     const response = handleApiError(error, "POST /api/search");

--- a/components/ResultCard.tsx
+++ b/components/ResultCard.tsx
@@ -363,13 +363,35 @@ export function ResultCard({
                           {formatPrice(result.maxPrice)}
                         </p>
                       )}
-                    {result.estimatedTotalMedian != null && (
-                      <p
-                        className="text-xs mt-1.5"
-                        style={{ color: "var(--cc-text-secondary)" }}
-                      >
-                        Est. total: {formatPrice(result.estimatedTotalMedian)}
-                      </p>
+                    {result.episodeEstimate?.estimatedAllInMedian != null ? (
+                      <div className="mt-1.5">
+                        <p
+                          className="text-xs font-medium"
+                          style={{ color: "var(--cc-text-secondary)" }}
+                        >
+                          Est. all-in:{" "}
+                          {formatPrice(
+                            result.episodeEstimate.estimatedAllInMedian
+                          )}
+                        </p>
+                        <p
+                          className="text-[11px]"
+                          style={{ color: "var(--cc-text-tertiary)" }}
+                        >
+                          {result.episodeEstimate.label} episode
+                          {result.episodeEstimate.coverageRatio < 1 &&
+                            ` (${Math.round(result.episodeEstimate.coverageRatio * 100)}% of components priced)`}
+                        </p>
+                      </div>
+                    ) : (
+                      result.estimatedTotalMedian != null && (
+                        <p
+                          className="text-xs mt-1.5"
+                          style={{ color: "var(--cc-text-secondary)" }}
+                        >
+                          Est. total: {formatPrice(result.estimatedTotalMedian)}
+                        </p>
+                      )
                     )}
                   </div>
                 </div>

--- a/lib/cpt/episode.ts
+++ b/lib/cpt/episode.ts
@@ -1,0 +1,326 @@
+import { createClient } from "@/lib/supabase/server";
+import { median } from "@/lib/cpt/lookup";
+import type { ChargeResult, EpisodeEstimate } from "@/types";
+
+// ---------------------------------------------------------------------------
+// Types for Supabase query results
+// ---------------------------------------------------------------------------
+
+interface EpisodeDefinitionRow {
+  id: string;
+  principal_code: string;
+  label: string;
+  category: string | null;
+}
+
+interface ComponentChargeRow {
+  provider_id: string;
+  component_code: string;
+  component_code_type: string;
+  component_tier: string;
+  component_association: number;
+  cash_price: number | null;
+  gross_charge: number | null;
+  avg_negotiated_rate: number | null;
+  min_price: number | null;
+  max_price: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Price extraction (matches extractReferencePrice priority in lookup.ts)
+// ---------------------------------------------------------------------------
+
+function extractComponentPrice(row: ComponentChargeRow): number | undefined {
+  const value =
+    row.cash_price ?? row.min_price ?? row.avg_negotiated_rate ?? row.max_price;
+  if (value == null || Number.isNaN(value) || value <= 0) return undefined;
+  return value;
+}
+
+const MIN_COVERAGE_RATIO = 0.5;
+
+// ---------------------------------------------------------------------------
+// Per-provider episode cost aggregation
+// ---------------------------------------------------------------------------
+
+interface ComponentSummary {
+  estimatePrice?: number;
+  minPrice?: number;
+  maxPrice?: number;
+}
+
+function summarizeComponentsForProvider(
+  providerRows: ComponentChargeRow[]
+): Map<string, ComponentSummary> {
+  const byCode = new Map<string, ComponentChargeRow[]>();
+  for (const row of providerRows) {
+    const existing = byCode.get(row.component_code) || [];
+    existing.push(row);
+    byCode.set(row.component_code, existing);
+  }
+
+  const summaries = new Map<string, ComponentSummary>();
+  for (const [code, rows] of byCode) {
+    let bestPrice: number | undefined;
+    let bestMin: number | undefined;
+    let bestMax: number | undefined;
+
+    for (const row of rows) {
+      const price = extractComponentPrice(row);
+      if (price != null && (bestPrice == null || price < bestPrice)) {
+        bestPrice = price;
+        const minVal =
+          row.min_price ?? row.cash_price ?? row.avg_negotiated_rate;
+        bestMin = minVal != null && minVal > 0 ? minVal : undefined;
+        const maxVal = row.max_price ?? row.cash_price ?? row.gross_charge;
+        bestMax = maxVal != null && maxVal > 0 ? maxVal : undefined;
+      }
+    }
+
+    summaries.set(code, {
+      estimatePrice: bestPrice,
+      minPrice: bestMin,
+      maxPrice: bestMax,
+    });
+  }
+
+  return summaries;
+}
+
+function computeLocalFallbacks(
+  allRows: ComponentChargeRow[]
+): Map<string, { median: number; min: number; max: number }> {
+  const byCode = new Map<string, number[]>();
+  for (const row of allRows) {
+    const price = extractComponentPrice(row);
+    if (price == null) continue;
+    const existing = byCode.get(row.component_code) || [];
+    existing.push(price);
+    byCode.set(row.component_code, existing);
+  }
+
+  const fallbacks = new Map<
+    string,
+    { median: number; min: number; max: number }
+  >();
+  for (const [code, prices] of byCode) {
+    if (prices.length === 0) continue;
+    fallbacks.set(code, {
+      median: median(prices),
+      min: Math.min(...prices),
+      max: Math.max(...prices),
+    });
+  }
+
+  return fallbacks;
+}
+
+// ---------------------------------------------------------------------------
+// Build EpisodeEstimate for a single provider
+// ---------------------------------------------------------------------------
+
+function buildEpisodeEstimate({
+  episodeDef,
+  providerComponents,
+  localFallbacks,
+  totalBillableComponents,
+  basePriceEstimate,
+}: {
+  episodeDef: EpisodeDefinitionRow;
+  providerComponents: Map<string, ComponentSummary>;
+  localFallbacks: Map<string, { median: number; min: number; max: number }>;
+  totalBillableComponents: number;
+  basePriceEstimate?: number;
+}): EpisodeEstimate {
+  let totalMedian = basePriceEstimate ?? 0;
+  let totalMin = basePriceEstimate ?? 0;
+  let totalMax = basePriceEstimate ?? 0;
+  let priceableCount = basePriceEstimate != null ? 1 : 0;
+
+  const allCodes = new Set([
+    ...providerComponents.keys(),
+    ...localFallbacks.keys(),
+  ]);
+
+  for (const code of allCodes) {
+    const providerSummary = providerComponents.get(code);
+    const fallback = localFallbacks.get(code);
+
+    const estimate = providerSummary?.estimatePrice ?? fallback?.median;
+    const min =
+      providerSummary?.minPrice ??
+      providerSummary?.estimatePrice ??
+      fallback?.min;
+    const max =
+      providerSummary?.maxPrice ??
+      providerSummary?.estimatePrice ??
+      fallback?.max;
+
+    if (estimate != null) {
+      totalMedian += estimate;
+      totalMin += min ?? estimate;
+      totalMax += max ?? estimate;
+      priceableCount++;
+    }
+  }
+
+  const componentCount = totalBillableComponents + 1;
+
+  return {
+    episodeId: episodeDef.id,
+    principalCode: episodeDef.principal_code,
+    label: episodeDef.label,
+    category: episodeDef.category ?? undefined,
+    estimatedAllInMedian: priceableCount > 0 ? totalMedian : undefined,
+    estimatedAllInMin: priceableCount > 0 ? totalMin : undefined,
+    estimatedAllInMax: priceableCount > 0 ? totalMax : undefined,
+    componentCount,
+    priceableCount,
+    coverageRatio: componentCount > 0 ? priceableCount / componentCount : 0,
+    source: "turquoise_ssp",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Process a single episode: collect matching results, query component charges,
+// and attach estimates to the results array.
+// ---------------------------------------------------------------------------
+
+async function processEpisode({
+  principalCode,
+  episodeDef,
+  results,
+  enrichedResults,
+  supabase,
+}: {
+  principalCode: string;
+  episodeDef: EpisodeDefinitionRow;
+  results: ChargeResult[];
+  enrichedResults: ChargeResult[];
+  supabase: Awaited<ReturnType<typeof createClient>>;
+}): Promise<void> {
+  const matchingIndices: number[] = [];
+  const providerIds = new Set<string>();
+
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i];
+    const resultCode = (r.cpt || r.hcpcs || "").trim().toUpperCase();
+    if (resultCode === principalCode) {
+      matchingIndices.push(i);
+      providerIds.add(r.provider.id);
+    }
+  }
+
+  if (providerIds.size === 0) return;
+
+  const { data: componentRows } = await supabase.rpc(
+    "lookup_episode_component_charges",
+    {
+      p_principal_code: principalCode,
+      p_provider_ids: Array.from(providerIds),
+      p_min_association: 0.4,
+    }
+  );
+
+  if (!componentRows || componentRows.length === 0) return;
+
+  const typedRows = componentRows as ComponentChargeRow[];
+  const billableCodes = new Set(typedRows.map((r) => r.component_code));
+  const totalBillableComponents = billableCodes.size;
+  const localFallbacks = computeLocalFallbacks(typedRows);
+
+  const rowsByProvider = new Map<string, ComponentChargeRow[]>();
+  for (const row of typedRows) {
+    const existing = rowsByProvider.get(row.provider_id) || [];
+    existing.push(row);
+    rowsByProvider.set(row.provider_id, existing);
+  }
+
+  for (const idx of matchingIndices) {
+    const result = enrichedResults[idx];
+    const providerRows = rowsByProvider.get(result.provider.id) || [];
+    const providerComponents = summarizeComponentsForProvider(providerRows);
+
+    const basePriceEstimate =
+      result.cashPrice ?? result.avgNegotiatedRate ?? result.grossCharge;
+
+    const estimate = buildEpisodeEstimate({
+      episodeDef,
+      providerComponents,
+      localFallbacks,
+      totalBillableComponents,
+      basePriceEstimate:
+        basePriceEstimate != null && basePriceEstimate > 0
+          ? basePriceEstimate
+          : undefined,
+    });
+
+    if (
+      estimate.estimatedAllInMedian != null &&
+      estimate.priceableCount > 1 &&
+      estimate.coverageRatio >= MIN_COVERAGE_RATIO
+    ) {
+      enrichedResults[idx] = {
+        ...result,
+        episodeEstimate: estimate,
+      };
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main enrichment function
+// ---------------------------------------------------------------------------
+
+export async function enrichWithEpisodeEstimates(
+  results: ChargeResult[]
+): Promise<ChargeResult[]> {
+  if (results.length === 0) return results;
+
+  try {
+    const supabase = await createClient();
+
+    const principalCodes = new Set<string>();
+    for (const result of results) {
+      if (result.cpt) principalCodes.add(result.cpt.trim().toUpperCase());
+      if (result.hcpcs) principalCodes.add(result.hcpcs.trim().toUpperCase());
+    }
+
+    if (principalCodes.size === 0) return results;
+
+    const { data: episodeDefs } = await supabase
+      .from("episode_definitions")
+      .select("id, principal_code, label, category")
+      .in("principal_code", Array.from(principalCodes));
+
+    if (!episodeDefs || episodeDefs.length === 0) return results;
+
+    const episodeByCode = new Map<string, EpisodeDefinitionRow>();
+    for (const def of episodeDefs) {
+      episodeByCode.set(def.principal_code, def);
+    }
+
+    const enrichedResults = [...results];
+
+    // Fire all episode RPC calls in parallel
+    await Promise.all(
+      Array.from(episodeByCode.entries()).map(([principalCode, episodeDef]) =>
+        processEpisode({
+          principalCode,
+          episodeDef,
+          results,
+          enrichedResults,
+          supabase,
+        })
+      )
+    );
+
+    return enrichedResults;
+  } catch (error) {
+    console.warn(
+      "Episode enrichment failed (non-fatal):",
+      error instanceof Error ? error.message : String(error)
+    );
+    return results;
+  }
+}

--- a/lib/cpt/lookup.ts
+++ b/lib/cpt/lookup.ts
@@ -363,7 +363,7 @@ function dedupeResultsById(results: ChargeResult[]): ChargeResult[] {
   return Array.from(byId.values());
 }
 
-function median(values: number[]): number {
+export function median(values: number[]): number {
   const sorted = [...values].sort((a, b) => a - b);
   const middle = Math.floor(sorted.length / 2);
   if (sorted.length % 2 === 0) {
@@ -372,7 +372,7 @@ function median(values: number[]): number {
   return sorted[middle];
 }
 
-function buildPriceSummary(values: number[]): PriceSummary | undefined {
+export function buildPriceSummary(values: number[]): PriceSummary | undefined {
   if (values.length === 0) return undefined;
   return {
     estimatePrice: median(values),

--- a/lib/data/import-ssps.ts
+++ b/lib/data/import-ssps.ts
@@ -1,0 +1,450 @@
+/**
+ * Import Turquoise Health Standard Service Packages (SSPs) into episode tables.
+ *
+ * Source: https://github.com/turquoisehealth/servicepackages.health
+ * Clone the repo, then point --dir at the `outputs/` directory.
+ *
+ * Run with:
+ *   npx tsx --env-file=.env.local lib/data/import-ssps.ts \
+ *     --dir /path/to/servicepackages.health/outputs
+ *
+ * Options:
+ *   --dir <path>            Path to SSP outputs/ directory (required)
+ *   --min-association <n>   Minimum association to import (default: 0.3)
+ *   --limit <n>             Limit number of SSP files processed (for testing)
+ *   --dry-run               Parse + stats, no DB writes
+ *   --fresh                 DELETE existing episode data before import
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import { readFileSync, readdirSync } from "fs";
+import { resolve, basename, dirname } from "path";
+import { fileURLToPath } from "url";
+import { parse as csvParse } from "csv-parse/sync";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// ---------------------------------------------------------------------------
+// Code type classification
+// ---------------------------------------------------------------------------
+
+function classifyCodeType(code: string): "cpt" | "hcpcs" | "revenue_code" {
+  const trimmed = code.trim();
+
+  // 4-digit codes starting with 0 are revenue codes (0360, 0636, etc.)
+  if (/^0\d{3}$/.test(trimmed)) return "revenue_code";
+
+  // Codes starting with a letter (C, G, J, Q, etc.) are HCPCS Level II
+  if (/^[A-Za-z]/.test(trimmed)) return "hcpcs";
+
+  // Everything else (5-digit numeric, Category III ending in T) = CPT
+  return "cpt";
+}
+
+function classifyPrincipalCodeType(code: string): "cpt" | "hcpcs" {
+  if (/^[A-Za-z]/.test(code.trim())) return "hcpcs";
+  return "cpt";
+}
+
+function classifyTier(
+  association: number
+): "required" | "expected" | "optional" {
+  if (association >= 0.7) return "required";
+  if (association >= 0.4) return "expected";
+  return "optional";
+}
+
+// ---------------------------------------------------------------------------
+// Category map for known procedure families
+// ---------------------------------------------------------------------------
+
+const CATEGORY_PATTERNS: Array<{ regex: RegExp; category: string }> = [
+  { regex: /^(27\d{3}|23\d{3}|29\d{3})$/, category: "orthopedic" },
+  { regex: /^(933\d{2}|935\d{2}|936\d{2}|37\d{3})$/, category: "cardiac" },
+  { regex: /^(45\d{3}|43\d{3}|44\d{3}|47\d{3})$/, category: "gi" },
+  { regex: /^(58\d{3}|57\d{3}|56\d{3})$/, category: "gyn" },
+  { regex: /^(66\d{3}|67\d{3}|65\d{3})$/, category: "ophthalmology" },
+  { regex: /^(35\d{3}|36\d{3}|34\d{3})$/, category: "vascular" },
+  { regex: /^(61\d{3}|62\d{3}|63\d{3})$/, category: "neurosurgery" },
+  { regex: /^(19\d{3})$/, category: "breast" },
+  {
+    regex: /^(50\d{3}|51\d{3}|52\d{3}|53\d{3}|54\d{3}|55\d{3})$/,
+    category: "urology",
+  },
+  { regex: /^(30\d{3}|31\d{3})$/, category: "ent" },
+  { regex: /^(49\d{3}|46\d{3}|42\d{3})$/, category: "general_surgery" },
+];
+
+function inferCategory(code: string): string | null {
+  for (const pattern of CATEGORY_PATTERNS) {
+    if (pattern.regex.test(code)) return pattern.category;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const opts: {
+    dir?: string;
+    minAssociation: number;
+    limit?: number;
+    dryRun: boolean;
+    fresh: boolean;
+  } = {
+    minAssociation: 0.3,
+    dryRun: false,
+    fresh: false,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--dir":
+        opts.dir = args[++i];
+        break;
+      case "--min-association":
+        opts.minAssociation = parseFloat(args[++i]);
+        break;
+      case "--limit":
+        opts.limit = parseInt(args[++i], 10);
+        break;
+      case "--dry-run":
+        opts.dryRun = true;
+        break;
+      case "--fresh":
+        opts.fresh = true;
+        break;
+    }
+  }
+
+  if (!opts.dir) {
+    console.error("Error: --dir <path> is required");
+    console.error(
+      "  npx tsx --env-file=.env.local lib/data/import-ssps.ts --dir /path/to/servicepackages.health/outputs"
+    );
+    process.exit(1);
+  }
+
+  return opts;
+}
+
+// ---------------------------------------------------------------------------
+// Label lookup
+// ---------------------------------------------------------------------------
+
+async function buildLabelMap(
+  supabase: ReturnType<typeof createClient>
+): Promise<Map<string, string>> {
+  const labels = new Map<string, string>();
+
+  // Source 1: medicare_benchmarks table (has descriptions for ~800 codes)
+  const { data: benchmarks } = await supabase
+    .from("medicare_benchmarks")
+    .select("code, description")
+    .not("description", "is", null);
+
+  if (benchmarks) {
+    for (const row of benchmarks) {
+      if (row.description) {
+        labels.set(row.code, row.description);
+      }
+    }
+  }
+
+  // Source 2: final-codes.json doesn't have descriptions, so skip it
+  // The medicare_benchmarks table is our best source of labels
+
+  console.log(`  Label sources: ${labels.size} from medicare_benchmarks`);
+  return labels;
+}
+
+// ---------------------------------------------------------------------------
+// CSV parsing
+// ---------------------------------------------------------------------------
+
+interface ParsedComponent {
+  code: string;
+  codeType: "cpt" | "hcpcs" | "revenue_code";
+  tier: "required" | "expected" | "optional";
+  association: number;
+  totalCount: number;
+  resolvedFrom: string[];
+}
+
+function parseSspCsv(
+  filePath: string,
+  minAssociation: number
+): ParsedComponent[] {
+  const content = readFileSync(filePath, "utf-8");
+  const rows: string[][] = csvParse(content, {
+    relax_column_count: true,
+    skip_empty_lines: true,
+  });
+
+  // CSV schema: cpt, total_count, association, resolveFroms
+  // First row is header
+  const components: ParsedComponent[] = [];
+
+  for (let i = 1; i < rows.length; i++) {
+    const row = rows[i];
+    if (!row || row.length < 3) continue;
+
+    const code = (row[0] ?? "").trim();
+    if (!code) continue;
+
+    const totalCount = parseInt(row[1] ?? "0", 10) || 0;
+    const association = parseFloat(row[2] ?? "0") || 0;
+
+    if (association < minAssociation) continue;
+
+    const resolvedFromRaw = (row[3] ?? "").trim();
+    const resolvedFrom = resolvedFromRaw
+      ? resolvedFromRaw
+          .split("|")
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : [];
+
+    components.push({
+      code,
+      codeType: classifyCodeType(code),
+      tier: classifyTier(association),
+      association,
+      totalCount,
+      resolvedFrom,
+    });
+  }
+
+  return components;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const opts = parseArgs();
+  const dirPath = resolve(opts.dir!);
+
+  console.log(`\n=== Turquoise SSP Import ===`);
+  console.log(`Directory: ${dirPath}`);
+  console.log(`Min association: ${opts.minAssociation}`);
+  if (opts.limit) console.log(`Limit: ${opts.limit} files`);
+  if (opts.dryRun) console.log("Mode: DRY RUN (no DB writes)");
+  if (opts.fresh) console.log("Mode: FRESH (will delete existing episodes)");
+
+  // Find all SSP CSV files
+  const allFiles = readdirSync(dirPath).filter(
+    (f) => f.startsWith("beta_sorted_") && f.endsWith(".csv")
+  );
+  allFiles.sort();
+
+  const files = opts.limit ? allFiles.slice(0, opts.limit) : allFiles;
+  console.log(`\nSSP files found: ${allFiles.length}`);
+  console.log(`Processing: ${files.length}`);
+
+  // Load our code list for overlap tracking
+  const finalCodesJson = readFileSync(
+    resolve(__dirname, "final-codes.json"),
+    "utf-8"
+  );
+  const ourCodes = new Set<string>(JSON.parse(finalCodesJson) as string[]);
+
+  // Parse all SSP files
+  interface EpisodeParsed {
+    principalCode: string;
+    principalCodeType: "cpt" | "hcpcs";
+    components: ParsedComponent[];
+  }
+
+  const episodes: EpisodeParsed[] = [];
+  let totalComponents = 0;
+  let overlapCount = 0;
+
+  const codeTypeStats = { cpt: 0, hcpcs: 0, revenue_code: 0 };
+  const tierStats = { required: 0, expected: 0, optional: 0 };
+
+  for (const file of files) {
+    // Extract principal code from filename: beta_sorted_27447.csv -> 27447
+    const match = file.match(/^beta_sorted_(.+)\.csv$/);
+    if (!match) continue;
+
+    const principalCode = match[1];
+    const components = parseSspCsv(resolve(dirPath, file), opts.minAssociation);
+
+    if (ourCodes.has(principalCode)) overlapCount++;
+
+    for (const comp of components) {
+      codeTypeStats[comp.codeType]++;
+      tierStats[comp.tier]++;
+    }
+
+    totalComponents += components.length;
+    episodes.push({
+      principalCode,
+      principalCodeType: classifyPrincipalCodeType(principalCode),
+      components,
+    });
+  }
+
+  console.log(`\n--- Parse Results ---`);
+  console.log(`Episodes parsed: ${episodes.length}`);
+  console.log(`Total components: ${totalComponents}`);
+  console.log(`Overlap with our codes: ${overlapCount}/${ourCodes.size}`);
+  console.log(`\nComponent code types:`);
+  console.log(`  CPT: ${codeTypeStats.cpt}`);
+  console.log(`  HCPCS: ${codeTypeStats.hcpcs}`);
+  console.log(`  Revenue: ${codeTypeStats.revenue_code}`);
+  console.log(`\nComponent tiers:`);
+  console.log(`  Required (>=0.7): ${tierStats.required}`);
+  console.log(`  Expected (0.4-0.7): ${tierStats.expected}`);
+  console.log(`  Optional (0.3-0.4): ${tierStats.optional}`);
+
+  if (opts.dryRun) {
+    console.log("\nDry run complete — no data written.");
+    process.exit(0);
+  }
+
+  // --- DB writes ---
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !supabaseKey) {
+    console.error(
+      "Error: NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required"
+    );
+    process.exit(1);
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseKey);
+
+  // Build label map
+  console.log("\nBuilding label map...");
+  const labelMap = await buildLabelMap(supabase);
+
+  if (opts.fresh) {
+    console.log("\nDeleting existing episode data...");
+    // Components cascade-delete with definitions
+    const { error } = await supabase
+      .from("episode_definitions")
+      .delete()
+      .neq("id", "00000000-0000-0000-0000-000000000000"); // delete all
+    if (error) {
+      console.error("Delete failed:", error.message);
+      process.exit(1);
+    }
+    console.log("Existing episode data deleted.");
+  }
+
+  // Phase 1: Upsert episode_definitions
+  console.log(`\nUpserting ${episodes.length} episode definitions...`);
+  const BATCH_SIZE = 100;
+  let defsInserted = 0;
+
+  // Map from principalCode -> episode UUID (needed for component inserts)
+  const episodeIdMap = new Map<string, string>();
+
+  for (let i = 0; i < episodes.length; i += BATCH_SIZE) {
+    const batch = episodes.slice(i, i + BATCH_SIZE).map((ep) => ({
+      ssp_code: ep.principalCode,
+      principal_code: ep.principalCode,
+      principal_code_type: ep.principalCodeType,
+      label: labelMap.get(ep.principalCode) || `Procedure ${ep.principalCode}`,
+      category: inferCategory(ep.principalCode),
+      source: "turquoise_ssp",
+      updated_at: new Date().toISOString(),
+    }));
+
+    const { data, error } = await supabase
+      .from("episode_definitions")
+      .upsert(batch, { onConflict: "ssp_code" })
+      .select("id, ssp_code");
+
+    if (error) {
+      console.error(
+        `Definition batch ${i / BATCH_SIZE + 1} failed:`,
+        error.message
+      );
+      process.exit(1);
+    }
+
+    if (data) {
+      for (const row of data) {
+        episodeIdMap.set(row.ssp_code, row.id);
+      }
+    }
+
+    defsInserted += batch.length;
+    if (defsInserted % 500 === 0 || defsInserted === episodes.length) {
+      console.log(
+        `  ${defsInserted} / ${episodes.length} definitions upserted`
+      );
+    }
+  }
+
+  // Phase 2: Upsert episode_components
+  console.log(`\nUpserting components...`);
+  let compsInserted = 0;
+  let compsSkipped = 0;
+
+  for (const ep of episodes) {
+    const episodeId = episodeIdMap.get(ep.principalCode);
+    if (!episodeId) {
+      compsSkipped += ep.components.length;
+      continue;
+    }
+
+    if (ep.components.length === 0) continue;
+
+    // Batch components for this episode
+    for (let i = 0; i < ep.components.length; i += BATCH_SIZE) {
+      const batch = ep.components.slice(i, i + BATCH_SIZE).map((comp) => ({
+        episode_id: episodeId,
+        code: comp.code,
+        code_type: comp.codeType,
+        tier: comp.tier,
+        association: comp.association,
+        total_count: comp.totalCount,
+        resolved_from: comp.resolvedFrom.length > 0 ? comp.resolvedFrom : null,
+      }));
+
+      const { error } = await supabase
+        .from("episode_components")
+        .upsert(batch, {
+          onConflict: "episode_id,code",
+          ignoreDuplicates: false,
+        });
+
+      if (error) {
+        console.error(
+          `Component batch for ${ep.principalCode} failed:`,
+          error.message
+        );
+        // Continue with other episodes rather than halting
+        compsSkipped += batch.length;
+        continue;
+      }
+
+      compsInserted += batch.length;
+    }
+
+    if (compsInserted % 5000 === 0 && compsInserted > 0) {
+      console.log(`  ${compsInserted} components upserted...`);
+    }
+  }
+
+  console.log(`\n=== Import Complete ===`);
+  console.log(`Episode definitions upserted: ${defsInserted}`);
+  console.log(`Episode components upserted: ${compsInserted}`);
+  if (compsSkipped > 0)
+    console.log(`Components skipped/failed: ${compsSkipped}`);
+  console.log(`Overlap with our ${ourCodes.size} codes: ${overlapCount}`);
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -640,3 +640,115 @@ create policy "Anyone can view payers" on payers for select using (true);
 create policy "Anyone can view translation cache" on translation_cache for select using (true);
 create policy "Anyone can insert translation cache" on translation_cache for insert with check (true);
 create policy "Anyone can update translation cache" on translation_cache for update using (true) with check (true);
+
+-- ============================================================================
+-- EPISODE DEFINITIONS (Turquoise Health Standard Service Packages)
+-- Maps principal procedure codes to typical co-occurring billing codes based
+-- on 2.7B Komodo Health claims. One row per SSP principal procedure.
+-- ~2,948 rows (all SSPs), though pricing enrichment only activates for codes
+-- that match search results.
+-- ============================================================================
+create table if not exists episode_definitions (
+  id uuid primary key default gen_random_uuid(),
+  ssp_code text unique not null,           -- Turquoise SSP identifier (= principal CPT/HCPCS)
+  principal_code text not null,            -- Primary procedure code
+  principal_code_type text not null default 'cpt', -- 'cpt' or 'hcpcs'
+  label text not null,                     -- Human-readable name ("Knee Replacement")
+  category text,                           -- Grouping: 'orthopedic', 'cardiac', etc.
+  source text default 'turquoise_ssp',
+  source_claim_count integer,              -- N claims underlying the SSP
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create index if not exists idx_episode_defs_principal on episode_definitions (principal_code);
+
+alter table episode_definitions enable row level security;
+create policy "Anyone can view episode definitions"
+  on episode_definitions for select using (true);
+
+-- ============================================================================
+-- EPISODE COMPONENTS (codes that typically co-occur with a principal procedure)
+-- Each row = one billing code observed in claims alongside the principal code.
+-- Tier classification based on association (frequency ratio from claims data):
+--   'required' >= 0.7, 'expected' 0.4-0.7, 'optional' 0.3-0.4
+-- ~44K rows at association >= 0.3 threshold.
+-- ============================================================================
+create table if not exists episode_components (
+  id uuid primary key default gen_random_uuid(),
+  episode_id uuid not null references episode_definitions(id) on delete cascade,
+  code text not null,                      -- Component billing code
+  code_type text not null,                 -- 'cpt', 'hcpcs', 'revenue_code'
+  tier text not null,                      -- 'required', 'expected', 'optional'
+  billing_class text,                      -- 'facility', 'professional'
+  association float not null,              -- 0.0-1.0+ frequency ratio
+  charge_weight float,                     -- % of total episode charge (future)
+  total_count integer,                     -- Claim count from SSP data
+  resolved_from text[],                    -- NCCI PTP merged codes
+  constraint uq_episode_component unique (episode_id, code)
+);
+
+create index if not exists idx_episode_components_episode on episode_components (episode_id);
+create index if not exists idx_episode_components_code on episode_components (code);
+
+alter table episode_components enable row level security;
+create policy "Anyone can view episode components"
+  on episode_components for select using (true);
+
+-- ============================================================================
+-- RPC: lookup_episode_component_charges()
+-- Batch lookup: given a principal procedure code and a set of provider IDs,
+-- returns charge data for all episode components at those providers.
+-- Used by the episode enrichment step in the search pipeline.
+-- Avoids N+1 queries by joining components → charges in a single call.
+-- ============================================================================
+create or replace function lookup_episode_component_charges(
+  p_principal_code text,
+  p_provider_ids uuid[],
+  p_min_association float default 0.4
+)
+returns table (
+  provider_id uuid,
+  component_code text,
+  component_code_type text,
+  component_tier text,
+  component_association float,
+  cash_price numeric,
+  gross_charge numeric,
+  avg_negotiated_rate numeric,
+  min_price numeric,
+  max_price numeric
+)
+language sql
+stable
+as $$
+  with episode as (
+    select id from episode_definitions
+    where principal_code = p_principal_code
+    limit 1
+  ),
+  components as (
+    select ec.code, ec.code_type, ec.tier, ec.association
+    from episode_components ec
+    join episode e on e.id = ec.episode_id
+    where ec.association >= p_min_association
+      and ec.code_type in ('cpt', 'hcpcs')
+  )
+  select
+    c.provider_id,
+    comp.code as component_code,
+    comp.code_type as component_code_type,
+    comp.tier as component_tier,
+    comp.association as component_association,
+    c.cash_price,
+    c.gross_charge,
+    c.avg_negotiated_rate,
+    c.min_price,
+    c.max_price
+  from components comp
+  join charges c on (
+    (comp.code_type = 'cpt' and (c.cpt = comp.code or c.hcpcs = comp.code))
+    or (comp.code_type = 'hcpcs' and c.hcpcs = comp.code)
+  )
+  where c.provider_id = any(p_provider_ids);
+$$;

--- a/types/index.ts
+++ b/types/index.ts
@@ -154,6 +154,9 @@ export interface ChargeResult {
   medicareFacilityRate?: number;
   medicareMultiplier?: number;
   medicareMultiplierSource?: "cash" | "insured" | "gross";
+
+  // Episode bundling (Turquoise SSP)
+  episodeEstimate?: EpisodeEstimate;
 }
 
 // -- Charge Variant (lightweight subset for grouped display) --
@@ -177,6 +180,21 @@ export interface ChargeVariant {
 export interface GroupedChargeResult extends ChargeResult {
   chargeVariants: ChargeVariant[];
   variantCount: number;
+}
+
+// -- Episode Estimate (Turquoise SSP-based all-in cost estimate) --
+export interface EpisodeEstimate {
+  episodeId: string;
+  principalCode: string;
+  label: string;
+  category?: string;
+  estimatedAllInMedian?: number;
+  estimatedAllInMin?: number;
+  estimatedAllInMax?: number;
+  componentCount: number;
+  priceableCount: number;
+  coverageRatio: number;
+  source: "turquoise_ssp";
 }
 
 // -- Medicare Benchmark (CMS Physician Fee Schedule national rate) --
@@ -218,6 +236,7 @@ export interface SearchResult {
   interpretation?: string;
   pricingPlan?: PricingPlan;
   totalResults: number;
+  hasEpisodeEstimates?: boolean;
 }
 
 // -- Guided Search: Clarification Flow Types --


### PR DESCRIPTION
## Summary

- Adds episode cost estimation using Turquoise Health Standard Service Packages (2.7B Komodo Health claims) to the search pipeline
- When a searched procedure has an SSP definition (120 of our 1,002 codes), the API returns an estimated all-in cost accounting for typical co-occurring services (anesthesia, pathology, drugs, etc.)
- Minimal UI: ResultCard shows "Est. all-in: $X" with episode label and coverage ratio

Closes #92

## What's included

**Database** (`supabase/schema.sql`):
- `episode_definitions` table — one row per SSP principal procedure (~2,948 rows)
- `episode_components` table — co-occurring codes with association scores (~44K rows)
- `lookup_episode_component_charges` RPC — batch lookup, avoids N+1 queries

**Import** (`lib/data/import-ssps.ts`):
- Parses all 2,948 SSP CSVs, classifies code types and tiers, batch-upserts
- CLI: `npx tsx --env-file=.env.local lib/data/import-ssps.ts --dir <path>`

**API enrichment** (`lib/cpt/episode.ts`):
- `enrichWithEpisodeEstimates()` — queries episode definitions, batch-fetches component charges, computes per-provider all-in estimates
- Parallelized with Medicare enrichment via `Promise.all` in new `enrichAndGroup` helper
- Non-critical: wrapped in try/catch, never breaks search
- Minimum 50% coverage gate prevents misleading sparse estimates

**Types** (`types/index.ts`):
- `EpisodeEstimate` interface on `ChargeResult`
- `hasEpisodeEstimates` flag on `SearchResult`

**UI** (`components/ResultCard.tsx`):
- Shows "Est. all-in: $X" + episode label when episode estimate exists
- Suppresses PricingPlan `estimatedTotalMedian` when SSP estimate is available (more authoritative)

## Prerequisites

- [ ] Apply SQL migration to Supabase (tables + RPC from schema.sql)
- [ ] Clone [turquoisehealth/servicepackages.health](https://github.com/turquoisehealth/servicepackages.health) and run import script
- [ ] Verify with "knee replacement" search near a metro area

## Test plan

- [ ] Search "knee replacement" near Miami — verify `episodeEstimate` in API response and "Est. all-in" on result cards
- [ ] Search "knee MRI" — verify no episode estimate (no SSP definition), existing PricingPlan adders still work
- [ ] Search "blood test" — verify no episode estimate, no regression
- [ ] Temporarily break RPC name in episode.ts → verify search still works without episode data

🤖 Generated with [Claude Code](https://claude.com/claude-code)