### PR TITLE
Allow same-location refresh on results page

### DIFF
--- a/app/results/useResultsSearch.ts
+++ b/app/results/useResultsSearch.ts
@@ -87,6 +87,7 @@ export function useResultsSearch() {
   const [error, setError] = useState<string | null>(null);
   const [view, setView] = useState<"list" | "map">("list");
   const [radius, setRadius] = useState<number>(25);
+  const [fetchCounter, setFetchCounter] = useState(0);
 
   useEffect(() => {
     if (
@@ -205,6 +206,7 @@ export function useResultsSearch() {
     directCodeType,
     directInterp,
     directPlanParam,
+    fetchCounter,
   ]);
 
   const handleNewSearch = useCallback(
@@ -236,6 +238,12 @@ export function useResultsSearch() {
         if (directCodeDescsParam) params.set("codeDescs", directCodeDescsParam);
 
         router.push(`/results?${params.toString()}`);
+
+        // Force re-fetch only when coordinates haven't changed (same-URL refresh).
+        // When they have changed, router.push updates searchParams → effect fires naturally.
+        if (location.lat === lat && location.lng === lng) {
+          setFetchCounter((c) => c + 1);
+        }
       } else {
         // Query changed or no resolved codes: full re-diagnosis needed
         const params = new URLSearchParams({
@@ -249,6 +257,8 @@ export function useResultsSearch() {
     },
     [
       query,
+      lat,
+      lng,
       directCodeGroups.length,
       directCodes.length,
       directCodeGroupsParam,


### PR DESCRIPTION
## Summary

- Adds a `fetchCounter` state to `useResultsSearch` that forces a re-fetch when the user clicks Search without changing location (same-URL refresh)
- Only increments the counter when coordinates are unchanged, preventing a double-fetch when location actually changes (where `router.push` alone triggers the effect via `lat`/`lng` dep changes)
- Adds `lat`/`lng` to `handleNewSearch` dependency array to satisfy exhaustive-deps lint rule

Closes #86

## Test plan

- [x] Search "knee MRI" in Miami → change location to Chicago → results update without guided search
- [x] Click Search again without changes → results re-fetch (new behavior)
- [x] Change query to "shoulder MRI" → routes to guided search
- [ ] Verify no double network requests in DevTools Network tab on location change

🤖 Generated with [Claude Code](https://claude.com/claude-code)