### PR TITLE
fix: collapse previously expanded card when opening a new one

### DIFF
--- a/components/ResultsList.tsx
+++ b/components/ResultsList.tsx
@@ -57,15 +57,9 @@ export function ResultsList({
   }, [markerClickCount]);
 
   const handleToggleExpand = useCallback((id: string) => {
-    setExpandedIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
-      }
-      return next;
-    });
+    setExpandedIds((prev) =>
+      prev.has(id) ? new Set<string>() : new Set([id])
+    );
   }, []);
 
   if (loading) {


### PR DESCRIPTION
## Summary
- Only one result card can be expanded at a time — clicking a new card automatically collapses the previous one
- Reduces visual clutter when scanning through dense pricing results
- Map marker clicks still expand all cards for the selected provider (intentional multi-expand)

## Test plan
- [ ] Click card #1 → expands
- [ ] Click card #2 → card #1 collapses, card #2 expands
- [ ] Click card #2 again → collapses (no cards expanded)
- [ ] Click a map marker for a provider with multiple cards → all cards for that provider expand

🤖 Generated with [Claude Code](https://claude.com/claude-code)