### PR TITLE
feat: results UX overhaul — table layout, search in navbar, fee breakdown

### DIFF
--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -192,10 +192,10 @@ function ResultsContent() {
         <div className="lg:flex lg:gap-4">
           {/* Left column: Results list */}
           <div
-            className={`lg:w-[55%] lg:overflow-y-auto lg:pr-2 ${
+            className={`lg:w-1/2 lg:overflow-y-auto lg:pr-2 ${
               view === "map" ? "hidden lg:block" : ""
             }`}
-            style={{ maxHeight: "calc(100vh - 240px)" }}
+            style={{ maxHeight: "calc(100vh - 200px)" }}
           >
             <ResultsList
               results={filteredResults}
@@ -212,10 +212,10 @@ function ResultsContent() {
 
           {/* Right column: Map */}
           <div
-            className={`lg:w-[45%] lg:sticky lg:top-[72px] mt-4 lg:mt-0 ${
+            className={`lg:w-1/2 lg:sticky lg:top-[72px] mt-4 lg:mt-0 ${
               view === "list" ? "hidden lg:block" : ""
             }`}
-            style={{ height: "calc(100vh - 240px)" }}
+            style={{ height: "calc(100vh - 200px)" }}
           >
             <MapView
               results={filteredResults}

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -90,7 +90,7 @@ function ResultsContent() {
     <div>
       {/* Filter bar + controls — flush below navbar */}
       <div
-        className="px-4 lg:px-6 border-b flex items-center gap-2"
+        className="px-4 lg:px-6 border-b flex items-center gap-2 overflow-x-auto"
         style={{ borderColor: "var(--cc-border)", background: "var(--cc-bg)" }}
       >
         {/* Mobile view toggle */}

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -87,136 +87,98 @@ function ResultsContent() {
   ]);
 
   return (
-    <div className="px-4 py-2">
-      {/* Header section — constrained width */}
-      <div className="max-w-5xl mx-auto lg:max-w-7xl">
-        {/* Error state */}
-        {error && (
-          <div
-            className="mt-4 p-4 rounded-xl border"
-            style={{
-              background: "var(--cc-error-light)",
-              borderColor: "rgba(220, 38, 38, 0.15)",
-            }}
-          >
-            <p className="text-sm" style={{ color: "var(--cc-error)" }}>
-              {error}
-            </p>
+    <div>
+      {/* Filter bar + controls — flush below navbar */}
+      <div
+        className="px-4 lg:px-6 border-b flex items-center gap-2"
+        style={{ borderColor: "var(--cc-border)", background: "var(--cc-bg)" }}
+      >
+        {/* Mobile view toggle */}
+        <div className="lg:hidden">
+          <div className="pill-group">
+            <button
+              onClick={() => setView("list")}
+              className={`pill-btn ${view === "list" ? "pill-btn-active" : ""}`}
+            >
+              List
+            </button>
+            <button
+              onClick={() => setView("map")}
+              className={`pill-btn ${view === "map" ? "pill-btn-active" : ""}`}
+            >
+              Map
+            </button>
           </div>
-        )}
-
-        {/* Interpretation — slim inline */}
-        {interpretation && !loading && (
-          <p
-            className="text-[12px] py-1.5"
-            style={{ color: "var(--cc-text-tertiary)" }}
-          >
-            <strong style={{ color: "var(--cc-primary)" }}>Interpreted:</strong>{" "}
-            {interpretation}
-            {cptCodes.length > 0 && (
-              <span
-                className="ml-1.5 text-[11px] px-1.5 py-0.5 rounded"
-                style={{
-                  background: "var(--cc-primary-light)",
-                  color: "var(--cc-primary)",
-                  fontWeight: 600,
-                }}
-              >
-                {cptCodes[0].codeType?.toUpperCase()} {cptCodes[0].code}
-              </span>
-            )}
-          </p>
-        )}
-
-        {/* Toolbar: View toggle (mobile only) + Save + Filters */}
-        <div className="mt-2">
-          <div className="flex flex-wrap items-center gap-2 lg:flex-nowrap lg:justify-between">
-            {/* Toggle pills: mobile only */}
-            <div className="lg:hidden">
-              <div className="pill-group">
-                <button
-                  onClick={() => setView("list")}
-                  className={`pill-btn ${view === "list" ? "pill-btn-active" : ""}`}
-                >
-                  <span className="flex items-center gap-1.5">
-                    <svg
-                      className="w-3.5 h-3.5"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    >
-                      <line x1="8" y1="6" x2="21" y2="6" />
-                      <line x1="8" y1="12" x2="21" y2="12" />
-                      <line x1="8" y1="18" x2="21" y2="18" />
-                      <line x1="3" y1="6" x2="3.01" y2="6" />
-                      <line x1="3" y1="12" x2="3.01" y2="12" />
-                      <line x1="3" y1="18" x2="3.01" y2="18" />
-                    </svg>
-                    List
-                  </span>
-                </button>
-                <button
-                  onClick={() => setView("map")}
-                  className={`pill-btn ${view === "map" ? "pill-btn-active" : ""}`}
-                >
-                  <span className="flex items-center gap-1.5">
-                    <svg
-                      className="w-3.5 h-3.5"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    >
-                      <polygon points="1 6 1 22 8 18 16 22 23 18 23 2 16 6 8 2 1 6" />
-                      <line x1="8" y1="2" x2="8" y2="18" />
-                      <line x1="16" y1="6" x2="16" y2="22" />
-                    </svg>
-                    Map
-                  </span>
-                </button>
-              </div>
-            </div>
-            {/* Spacer on desktop where toggle was */}
-            <div className="hidden lg:block" />
-
-            {!loading && results.length > 0 && (
-              <SaveButton
-                query={query}
-                location={locationDisplay}
-                cptCodes={cptCodes.map((c) => c.code)}
-                lat={lat}
-                lng={lng}
-                onSave={logSaveSearch}
-              />
-            )}
-          </div>
-
-          {/* Filter bar */}
-          {!loading && results.length > 0 && (
-            <FilterBar
-              results={results}
-              onFilteredResults={handleFilteredResults}
-              radius={radius}
-              onRadiusChange={handleRadiusChange}
-            />
-          )}
         </div>
+
+        {/* Filters */}
+        {!loading && results.length > 0 && (
+          <FilterBar
+            results={results}
+            onFilteredResults={handleFilteredResults}
+            radius={radius}
+            onRadiusChange={handleRadiusChange}
+          />
+        )}
+
+        <div className="flex-1" />
+
+        {/* Interpretation — icon with tooltip */}
+        {interpretation && !loading && (
+          <span
+            className="text-[11px] px-1.5 py-0.5 rounded cursor-help hidden sm:inline-flex items-center gap-1"
+            style={{
+              background: "var(--cc-primary-light)",
+              color: "var(--cc-primary)",
+              fontWeight: 500,
+            }}
+            title={interpretation}
+          >
+            {cptCodes.length > 0 && (
+              <>
+                {cptCodes[0].codeType?.toUpperCase()} {cptCodes[0].code}
+              </>
+            )}
+          </span>
+        )}
+
+        {/* Save — small icon button */}
+        {!loading && results.length > 0 && (
+          <SaveButton
+            query={query}
+            location={locationDisplay}
+            cptCodes={cptCodes.map((c) => c.code)}
+            lat={lat}
+            lng={lng}
+            onSave={logSaveSearch}
+          />
+        )}
       </div>
 
+      {/* Error state */}
+      {error && (
+        <div
+          className="mx-4 mt-2 p-3 rounded-lg border"
+          style={{
+            background: "var(--cc-error-light)",
+            borderColor: "rgba(220, 38, 38, 0.15)",
+          }}
+        >
+          <p className="text-sm" style={{ color: "var(--cc-error)" }}>
+            {error}
+          </p>
+        </div>
+      )}
+
       {/* Content section — split view on desktop, toggle on mobile */}
-      <div className="max-w-5xl mx-auto lg:max-w-7xl mt-2">
+      <div className="max-w-full px-4 lg:px-6">
         <div className="lg:flex lg:gap-4">
           {/* Left column: Results list */}
           <div
             className={`lg:w-1/2 lg:overflow-y-auto lg:pr-2 ${
               view === "map" ? "hidden lg:block" : ""
             }`}
-            style={{ maxHeight: "calc(100vh - 200px)" }}
+            style={{ maxHeight: "calc(100vh - 120px)" }}
           >
             <ResultsList
               results={filteredResults}
@@ -236,7 +198,7 @@ function ResultsContent() {
             className={`lg:w-1/2 lg:sticky lg:top-[72px] mt-4 lg:mt-0 ${
               view === "list" ? "hidden lg:block" : ""
             }`}
-            style={{ height: "calc(100vh - 200px)" }}
+            style={{ height: "calc(100vh - 120px)" }}
           >
             <MapView
               results={filteredResults}

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useCallback, useEffect, useMemo } from "react";
+import { Suspense, useCallback, useEffect } from "react";
 import { SearchBar } from "@/components/SearchBar";
 import { ResultsList } from "@/components/ResultsList";
 import { useNavbarSlot } from "@/components/NavbarContext";
@@ -52,14 +52,6 @@ function ResultsContent() {
     handleMarkerClick,
     handleCardSelect,
   } = useResultSelection();
-
-  const codeDescriptionMap = useMemo(() => {
-    const map: Record<string, string> = {};
-    for (const code of cptCodes) {
-      if (code.code && code.description) map[code.code] = code.description;
-    }
-    return map;
-  }, [cptCodes]);
 
   // Inject search bar + interpretation into the navbar
   const { setSearchSlot } = useNavbarSlot();
@@ -248,7 +240,6 @@ function ResultsContent() {
               markerClickCount={markerClickCount}
               onCardSelect={handleCardSelect}
               onResultClick={logResultClick}
-              codeDescriptionMap={codeDescriptionMap}
               locationDisplay={locationDisplay}
               onExpandRadius={radius < 250 ? handleExpandRadius : undefined}
             />

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -65,38 +65,15 @@ function ResultsContent() {
   const { setSearchSlot } = useNavbarSlot();
   useEffect(() => {
     setSearchSlot(
-      <div className="min-w-0">
-        <SearchBar
-          onSearch={handleNewSearch}
-          loading={loading}
-          initialQuery={query}
-          initialLocation={
-            lat && lng ? { lat, lng, display: locationDisplay } : undefined
-          }
-          compact
-        />
-        {interpretation && !loading && (
-          <p
-            className="text-[11px] mt-1 leading-tight"
-            style={{ color: "var(--cc-text-tertiary)" }}
-          >
-            <strong style={{ color: "var(--cc-primary)" }}>Interpreted:</strong>{" "}
-            {interpretation}
-            {cptCodes.length > 0 && (
-              <span
-                className="ml-1 text-[10px] px-1 py-0.5 rounded"
-                style={{
-                  background: "var(--cc-primary-light)",
-                  color: "var(--cc-primary)",
-                  fontWeight: 600,
-                }}
-              >
-                {cptCodes[0].codeType?.toUpperCase()} {cptCodes[0].code}
-              </span>
-            )}
-          </p>
-        )}
-      </div>
+      <SearchBar
+        onSearch={handleNewSearch}
+        loading={loading}
+        initialQuery={query}
+        initialLocation={
+          lat && lng ? { lat, lng, display: locationDisplay } : undefined
+        }
+        compact
+      />
     );
     return () => setSearchSlot(null);
   }, [
@@ -107,8 +84,6 @@ function ResultsContent() {
     lat,
     lng,
     locationDisplay,
-    interpretation,
-    cptCodes,
   ]);
 
   return (
@@ -128,6 +103,29 @@ function ResultsContent() {
               {error}
             </p>
           </div>
+        )}
+
+        {/* Interpretation — slim inline */}
+        {interpretation && !loading && (
+          <p
+            className="text-[12px] py-1.5"
+            style={{ color: "var(--cc-text-tertiary)" }}
+          >
+            <strong style={{ color: "var(--cc-primary)" }}>Interpreted:</strong>{" "}
+            {interpretation}
+            {cptCodes.length > 0 && (
+              <span
+                className="ml-1.5 text-[11px] px-1.5 py-0.5 rounded"
+                style={{
+                  background: "var(--cc-primary-light)",
+                  color: "var(--cc-primary)",
+                  fontWeight: 600,
+                }}
+              >
+                {cptCodes[0].codeType?.toUpperCase()} {cptCodes[0].code}
+              </span>
+            )}
+          </p>
         )}
 
         {/* Toolbar: View toggle (mobile only) + Save + Filters */}

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -121,25 +121,86 @@ function ResultsContent() {
           />
         )}
 
+        {/* Results count */}
+        {!loading && filteredResults.length > 0 && (
+          <span
+            className="text-[12px] whitespace-nowrap"
+            style={{ color: "var(--cc-text-tertiary)" }}
+          >
+            {filteredResults.length} result
+            {filteredResults.length !== 1 ? "s" : ""}
+          </span>
+        )}
+
         <div className="flex-1" />
 
-        {/* Interpretation — icon with tooltip */}
+        {/* Interpretation — label + code pill with hover tooltip */}
         {interpretation && !loading && (
-          <span
-            className="text-[11px] px-1.5 py-0.5 rounded cursor-help hidden sm:inline-flex items-center gap-1"
-            style={{
-              background: "var(--cc-primary-light)",
-              color: "var(--cc-primary)",
-              fontWeight: 500,
-            }}
-            title={interpretation}
-          >
-            {cptCodes.length > 0 && (
-              <>
-                {cptCodes[0].codeType?.toUpperCase()} {cptCodes[0].code}
-              </>
-            )}
-          </span>
+          <div className="relative hidden sm:inline-flex items-center group">
+            <span
+              className="text-[11px] px-1.5 py-0.5 rounded cursor-help inline-flex items-center gap-1"
+              style={{
+                background: "var(--cc-primary-light)",
+                color: "var(--cc-primary)",
+                fontWeight: 500,
+              }}
+            >
+              Interpreted:
+              {cptCodes.length > 0 && (
+                <span className="font-semibold">
+                  {cptCodes[0].codeType?.toUpperCase()} {cptCodes[0].code}
+                </span>
+              )}
+              <svg
+                className="w-3 h-3"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <circle cx="12" cy="12" r="10" />
+                <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+                <line x1="12" y1="17" x2="12.01" y2="17" />
+              </svg>
+            </span>
+            {/* Hover tooltip */}
+            <div
+              className="absolute top-full right-0 mt-1 p-3 rounded-lg border text-[12px] w-80 z-50 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-150"
+              style={{
+                background: "var(--cc-surface)",
+                borderColor: "var(--cc-border)",
+                color: "var(--cc-text-secondary)",
+                boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
+              }}
+            >
+              <p
+                className="font-semibold mb-1"
+                style={{ color: "var(--cc-text)" }}
+              >
+                How we interpreted your search
+              </p>
+              <p>{interpretation}</p>
+              {cptCodes.length > 0 && (
+                <div className="flex flex-wrap gap-1 mt-2">
+                  {cptCodes.map((code) => (
+                    <span
+                      key={code.code}
+                      className="text-[10px] px-1.5 py-0.5 rounded font-medium"
+                      style={{
+                        background: "var(--cc-primary-light)",
+                        color: "var(--cc-primary)",
+                      }}
+                    >
+                      {(code.codeType || "CPT").toUpperCase()} {code.code}:{" "}
+                      {code.description}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
         )}
 
         {/* Save — small icon button */}

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -65,29 +65,26 @@ function ResultsContent() {
   const { setSearchSlot } = useNavbarSlot();
   useEffect(() => {
     setSearchSlot(
-      <div className="flex items-center gap-3 min-w-0">
-        <div className="flex-1 min-w-0">
-          <SearchBar
-            onSearch={handleNewSearch}
-            loading={loading}
-            initialQuery={query}
-            initialLocation={
-              lat && lng ? { lat, lng, display: locationDisplay } : undefined
-            }
-            compact
-          />
-        </div>
+      <div className="min-w-0">
+        <SearchBar
+          onSearch={handleNewSearch}
+          loading={loading}
+          initialQuery={query}
+          initialLocation={
+            lat && lng ? { lat, lng, display: locationDisplay } : undefined
+          }
+          compact
+        />
         {interpretation && !loading && (
-          <span
-            className="text-[12px] hidden lg:block"
-            style={{ color: "var(--cc-text-secondary)" }}
-            title={interpretation}
+          <p
+            className="text-[11px] mt-1 leading-tight"
+            style={{ color: "var(--cc-text-tertiary)" }}
           >
             <strong style={{ color: "var(--cc-primary)" }}>Interpreted:</strong>{" "}
             {interpretation}
             {cptCodes.length > 0 && (
               <span
-                className="ml-1.5 text-[11px] px-1.5 py-0.5 rounded"
+                className="ml-1 text-[10px] px-1 py-0.5 rounded"
                 style={{
                   background: "var(--cc-primary-light)",
                   color: "var(--cc-primary)",
@@ -97,7 +94,7 @@ function ResultsContent() {
                 {cptCodes[0].codeType?.toUpperCase()} {cptCodes[0].code}
               </span>
             )}
-          </span>
+          </p>
         )}
       </div>
     );

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -79,7 +79,7 @@ function ResultsContent() {
         </div>
         {interpretation && !loading && (
           <span
-            className="text-[12px] truncate hidden lg:block max-w-[300px]"
+            className="text-[12px] hidden lg:block"
             style={{ color: "var(--cc-text-secondary)" }}
             title={interpretation}
           >

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -6,7 +6,6 @@ import { ResultsList } from "@/components/ResultsList";
 import { FilterBar } from "@/components/FilterBar";
 import { MapView } from "@/components/MapView";
 import { SaveButton } from "@/components/SaveButton";
-import { CostContextBanner } from "@/components/CostContextBanner";
 import type { CPTCode, PricingPlan } from "@/types";
 import { useResultsSearch } from "./useResultsSearch";
 import { useResultSelection } from "./useResultSelection";
@@ -100,11 +99,6 @@ function ResultsContent() {
               {error}
             </p>
           </div>
-        )}
-
-        {/* Cost context banner */}
-        {!loading && results.length > 0 && (
-          <CostContextBanner cptCodes={cptCodes} results={results} />
         )}
 
         {/* Toolbar: View toggle (mobile only) + Save + Filters */}

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { Suspense, useCallback, useMemo, useState } from "react";
+import { Suspense, useCallback, useEffect, useMemo } from "react";
 import { SearchBar } from "@/components/SearchBar";
 import { ResultsList } from "@/components/ResultsList";
+import { useNavbarSlot } from "@/components/NavbarContext";
 import { FilterBar } from "@/components/FilterBar";
 import { MapView } from "@/components/MapView";
 import { SaveButton } from "@/components/SaveButton";
-import type { CPTCode, PricingPlan } from "@/types";
 import { useResultsSearch } from "./useResultsSearch";
 import { useResultSelection } from "./useResultSelection";
 
@@ -22,7 +22,6 @@ function ResultsContent() {
     filteredResults,
     cptCodes,
     interpretation,
-    pricingPlan,
     loading,
     error,
     view,
@@ -62,30 +61,63 @@ function ResultsContent() {
     return map;
   }, [cptCodes]);
 
+  // Inject search bar + interpretation into the navbar
+  const { setSearchSlot } = useNavbarSlot();
+  useEffect(() => {
+    setSearchSlot(
+      <div className="flex items-center gap-3 min-w-0">
+        <div className="flex-1 min-w-0">
+          <SearchBar
+            onSearch={handleNewSearch}
+            loading={loading}
+            initialQuery={query}
+            initialLocation={
+              lat && lng ? { lat, lng, display: locationDisplay } : undefined
+            }
+            compact
+          />
+        </div>
+        {interpretation && !loading && (
+          <span
+            className="text-[12px] truncate hidden lg:block max-w-[300px]"
+            style={{ color: "var(--cc-text-secondary)" }}
+            title={interpretation}
+          >
+            <strong style={{ color: "var(--cc-primary)" }}>Interpreted:</strong>{" "}
+            {interpretation}
+            {cptCodes.length > 0 && (
+              <span
+                className="ml-1.5 text-[11px] px-1.5 py-0.5 rounded"
+                style={{
+                  background: "var(--cc-primary-light)",
+                  color: "var(--cc-primary)",
+                  fontWeight: 600,
+                }}
+              >
+                {cptCodes[0].codeType?.toUpperCase()} {cptCodes[0].code}
+              </span>
+            )}
+          </span>
+        )}
+      </div>
+    );
+    return () => setSearchSlot(null);
+  }, [
+    setSearchSlot,
+    handleNewSearch,
+    loading,
+    query,
+    lat,
+    lng,
+    locationDisplay,
+    interpretation,
+    cptCodes,
+  ]);
+
   return (
-    <div className="px-4 py-3">
+    <div className="px-4 py-2">
       {/* Header section — constrained width */}
       <div className="max-w-5xl mx-auto lg:max-w-7xl">
-        {/* Search bar (compact) */}
-        <SearchBar
-          onSearch={handleNewSearch}
-          loading={loading}
-          initialQuery={query}
-          initialLocation={
-            lat && lng ? { lat, lng, display: locationDisplay } : undefined
-          }
-          compact
-        />
-
-        {/* Interpretation banner (collapsible) */}
-        {interpretation && !loading && (
-          <InterpretationBanner
-            interpretation={interpretation}
-            pricingPlan={pricingPlan}
-            cptCodes={cptCodes}
-          />
-        )}
-
         {/* Error state */}
         {error && (
           <div
@@ -218,145 +250,6 @@ function ResultsContent() {
               selectedProviderId={selectedProviderId}
               className="h-full"
             />
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function InterpretationBanner({
-  interpretation,
-  pricingPlan,
-  cptCodes,
-}: {
-  interpretation: string;
-  pricingPlan: PricingPlan | undefined;
-  cptCodes: CPTCode[];
-}) {
-  const [expanded, setExpanded] = useState(false);
-  const firstTwoCodes = cptCodes.slice(0, 2);
-  const overflowCount = cptCodes.length - 2;
-
-  return (
-    <div
-      className="mt-2 rounded-xl border animate-fade-in"
-      style={{
-        background: "var(--cc-primary-light)",
-        borderColor: "rgba(15, 118, 110, 0.12)",
-      }}
-    >
-      {/* Collapsed row */}
-      <button
-        className="w-full flex items-center gap-2 px-3 py-2 text-left"
-        onClick={() => setExpanded((v) => !v)}
-        aria-expanded={expanded}
-      >
-        <svg
-          className="w-4 h-4 shrink-0"
-          style={{ color: "var(--cc-primary)" }}
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <path d="M12 8V4H8" />
-          <rect width="16" height="12" x="4" y="8" rx="2" />
-          <path d="M2 14h2M20 14h2M15 13v2M9 13v2" />
-        </svg>
-        <span
-          className="text-sm truncate min-w-0"
-          style={{ color: "var(--cc-primary)" }}
-        >
-          <span className="font-semibold">Interpreted as:</span>{" "}
-          {interpretation}
-        </span>
-        {!expanded && cptCodes.length > 0 && (
-          <span className="flex items-center gap-1 shrink-0">
-            {firstTwoCodes.map((code) => (
-              <span
-                key={code.code}
-                className="text-[11px] px-1.5 py-0.5 rounded-md font-medium hidden sm:inline"
-                style={{
-                  background: "rgba(15, 118, 110, 0.1)",
-                  color: "var(--cc-primary)",
-                }}
-              >
-                {(code.codeType || "CPT").toUpperCase()} {code.code}
-              </span>
-            ))}
-            {overflowCount > 0 && (
-              <span
-                className="text-[11px] font-medium hidden sm:inline"
-                style={{ color: "var(--cc-primary)" }}
-              >
-                +{overflowCount}
-              </span>
-            )}
-          </span>
-        )}
-        <svg
-          className="w-4 h-4 shrink-0 transition-transform duration-200"
-          style={{
-            color: "var(--cc-primary)",
-            transform: expanded ? "rotate(180deg)" : "rotate(0deg)",
-          }}
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <polyline points="6 9 12 15 18 9" />
-        </svg>
-      </button>
-
-      {/* Expanded content */}
-      <div className={`accordion-body ${expanded ? "expanded" : ""}`}>
-        <div>
-          <div className="px-3 pb-3">
-            {pricingPlan?.mode === "encounter_first" && (
-              <p
-                className="text-xs mb-2"
-                style={{ color: "var(--cc-primary)" }}
-              >
-                Showing a visit-first estimate; any imaging or lab work is
-                listed below as possible additional costs.
-              </p>
-            )}
-            {cptCodes.length > 0 && (
-              <div className="flex flex-wrap gap-1.5">
-                {cptCodes.map((code) => (
-                  <span
-                    key={code.code}
-                    className="text-xs px-2 py-0.5 rounded-md font-medium"
-                    style={{
-                      background: "rgba(15, 118, 110, 0.1)",
-                      color: "var(--cc-primary)",
-                    }}
-                  >
-                    {(code.codeType || "CPT").toUpperCase()} {code.code}:{" "}
-                    {code.description}
-                  </span>
-                ))}
-              </div>
-            )}
-            {cptCodes.length > 0 && (
-              <p
-                className="text-xs mt-2 px-2.5 py-2 rounded-md leading-relaxed"
-                style={{
-                  background: "var(--cc-bg)",
-                  color: "var(--cc-text-tertiary)",
-                }}
-              >
-                These codes are our interpretation of your search. Your provider
-                may bill differently — confirm codes and pricing before your
-                visit.
-              </p>
-            )}
           </div>
         </div>
       </div>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -6,7 +6,7 @@ export function Footer() {
       className="border-t px-4 sm:px-8 py-12 sm:py-16"
       style={{
         borderColor: "var(--cc-border)",
-        background: "var(--cc-bg)",
+        background: "var(--cc-surface-alt)",
       }}
     >
       <div className="max-w-4xl mx-auto">

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -2,19 +2,24 @@
 
 import Link from "next/link";
 import { AuthButton } from "./AuthButton";
+import { useNavbarSlot } from "./NavbarContext";
 
 export function Navbar() {
+  const { searchSlot } = useNavbarSlot();
+
   return (
     <nav
-      className="sticky top-0 z-50 border-b px-4 lg:px-8 h-14 flex items-center justify-between"
+      className="sticky top-0 z-50 border-b px-4 lg:px-6 flex items-center gap-4"
       style={{
         background: "rgba(250, 250, 248, 0.85)",
         backdropFilter: "blur(12px)",
         WebkitBackdropFilter: "blur(12px)",
         borderColor: "var(--cc-border)",
+        height: searchSlot ? "auto" : "56px",
+        padding: searchSlot ? "8px 16px" : undefined,
       }}
     >
-      <Link href="/" className="flex items-center gap-2 group">
+      <Link href="/" className="flex items-center gap-2 group shrink-0">
         <div
           className="w-6 h-6 rounded-md flex items-center justify-center"
           style={{ background: "var(--cc-primary)" }}
@@ -33,7 +38,7 @@ export function Navbar() {
           </svg>
         </div>
         <span
-          className="text-lg group-hover:opacity-80 transition-opacity"
+          className="text-lg group-hover:opacity-80 transition-opacity hidden sm:inline"
           style={{
             fontFamily: "var(--font-instrument-serif), Georgia, serif",
             color: "var(--cc-text)",
@@ -43,7 +48,10 @@ export function Navbar() {
         </span>
       </Link>
 
-      <div className="flex items-center gap-1">
+      {/* Search slot — injected by results page via NavbarContext */}
+      {searchSlot && <div className="flex-1 min-w-0">{searchSlot}</div>}
+
+      <div className="flex items-center gap-1 shrink-0">
         <Link
           href="/saved"
           className="px-3 py-1.5 rounded-lg text-sm font-medium hover:bg-[var(--cc-surface-alt)] transition-colors"

--- a/components/NavbarContext.tsx
+++ b/components/NavbarContext.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { createContext, useContext, useState, type ReactNode } from "react";
+
+interface NavbarContextValue {
+  searchSlot: ReactNode | null;
+  setSearchSlot: (node: ReactNode | null) => void;
+}
+
+const NavbarContext = createContext<NavbarContextValue>({
+  searchSlot: null,
+  setSearchSlot: () => {},
+});
+
+export function NavbarProvider({ children }: { children: ReactNode }) {
+  const [searchSlot, setSearchSlot] = useState<ReactNode | null>(null);
+  return (
+    <NavbarContext.Provider value={{ searchSlot, setSearchSlot }}>
+      {children}
+    </NavbarContext.Provider>
+  );
+}
+
+export const useNavbarSlot = () => useContext(NavbarContext);

--- a/components/Providers.tsx
+++ b/components/Providers.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { Toaster } from "react-hot-toast";
+import { NavbarProvider } from "./NavbarContext";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <>
+    <NavbarProvider>
       <Toaster
         position="top-right"
         toastOptions={{
@@ -31,6 +32,6 @@ export function Providers({ children }: { children: React.ReactNode }) {
         }}
       />
       {children}
-    </>
+    </NavbarProvider>
   );
 }

--- a/components/ResultRow.tsx
+++ b/components/ResultRow.tsx
@@ -96,7 +96,7 @@ export function ResultRow({
       {/* Base Price — first, normal weight */}
       <div
         role="cell"
-        className="text-[13px]"
+        className="text-[13px] text-right tabular-nums"
         style={{ color: priceColor(baseAmount, priceRange) }}
       >
         {formatPrice(baseAmount)}
@@ -105,7 +105,7 @@ export function ResultRow({
       {/* Est. Total — bold, color-coded */}
       <div
         role="cell"
-        className="font-bold text-[15px] hidden sm:block"
+        className="font-bold text-[15px] text-right tabular-nums hidden sm:block"
         style={{ color: priceColor(estAmount, priceRange) }}
       >
         {formatPrice(estAmount)}
@@ -114,7 +114,7 @@ export function ResultRow({
       {/* Distance */}
       <div
         role="cell"
-        className="text-[12px]"
+        className="text-[12px] text-right"
         style={{ color: "var(--cc-text-tertiary)" }}
       >
         {distance}

--- a/components/ResultRow.tsx
+++ b/components/ResultRow.tsx
@@ -19,6 +19,7 @@ interface ResultRowProps {
 }
 
 const ROW_GRID = "1fr 90px 100px 65px 80px 24px";
+const ROW_GAP = "16px";
 
 /** Returns a color based on where the price falls in the range: green (low), amber (mid), red (high) */
 function priceColor(
@@ -55,6 +56,7 @@ export function ResultRow({
       className="grid items-center cursor-pointer select-none transition-colors duration-100 hover:bg-[var(--cc-surface-hover)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--cc-primary)]"
       style={{
         gridTemplateColumns: ROW_GRID,
+        gap: ROW_GAP,
         padding: "10px 16px",
         borderBottom: isExpanded ? "none" : "1px solid var(--cc-border)",
         background:
@@ -149,4 +151,4 @@ export function ResultRow({
   );
 }
 
-export { ROW_GRID };
+export { ROW_GRID, ROW_GAP };

--- a/components/ResultRow.tsx
+++ b/components/ResultRow.tsx
@@ -18,9 +18,6 @@ interface ResultRowProps {
   priceRange?: { min: number; max: number };
 }
 
-const ROW_GRID = "1fr 90px 100px 65px 80px 24px";
-const ROW_GAP = "16px";
-
 /** Returns a color based on where the price falls in the range: green (low), amber (mid), red (high) */
 function priceColor(
   price: number | undefined,
@@ -28,9 +25,9 @@ function priceColor(
 ): string {
   if (!price || !range || range.max === range.min) return "var(--cc-text)";
   const ratio = (price - range.min) / (range.max - range.min);
-  if (ratio <= 0.33) return "var(--cc-success)"; // green — low end
-  if (ratio <= 0.66) return "var(--cc-accent)"; // amber — mid
-  return "var(--cc-error)"; // red — high end
+  if (ratio <= 0.33) return "var(--cc-success)";
+  if (ratio <= 0.66) return "var(--cc-accent)";
+  return "var(--cc-error)";
 }
 
 export function ResultRow({
@@ -50,20 +47,14 @@ export function ResultRow({
   const estAmount = estTotal ?? baseAmount;
 
   return (
-    <div
+    <tr
       data-result-id={result.id}
       data-provider-id={result.provider.id}
-      className="grid items-center cursor-pointer select-none transition-colors duration-100 hover:bg-[var(--cc-surface-hover)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--cc-primary)]"
+      className="cursor-pointer select-none transition-colors duration-100 hover:bg-[var(--cc-surface-hover)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--cc-primary)]"
       style={{
-        gridTemplateColumns: ROW_GRID,
-        gap: ROW_GAP,
-        padding: "10px 16px",
-        borderBottom: isExpanded ? "none" : "1px solid var(--cc-border)",
         background:
           isExpanded || isSelected ? "var(--cc-primary-light)" : undefined,
       }}
-      role="row"
-      aria-expanded={isExpanded}
       tabIndex={0}
       onClick={() => {
         onToggleExpand?.();
@@ -78,9 +69,14 @@ export function ResultRow({
       }}
     >
       {/* Provider */}
-      <div role="cell" className="min-w-0">
+      <td
+        className="py-2.5 px-4"
+        style={{
+          borderBottom: isExpanded ? "none" : "1px solid var(--cc-border)",
+        }}
+      >
         <div
-          className="font-semibold text-[13px] truncate"
+          className="font-semibold text-[13px] truncate max-w-[300px]"
           style={{ color: "var(--cc-text)" }}
         >
           {displayName(result.provider.name)}
@@ -91,48 +87,62 @@ export function ResultRow({
         >
           {result.setting || "Outpatient"}
         </div>
-      </div>
+      </td>
 
-      {/* Base Price — first, normal weight */}
-      <div
-        role="cell"
-        className="text-[13px] text-right tabular-nums"
-        style={{ color: priceColor(baseAmount, priceRange) }}
+      {/* Base Price */}
+      <td
+        className="py-2.5 px-4 text-right tabular-nums text-[13px]"
+        style={{
+          color: priceColor(baseAmount, priceRange),
+          borderBottom: isExpanded ? "none" : "1px solid var(--cc-border)",
+        }}
       >
         {formatPrice(baseAmount)}
-      </div>
+      </td>
 
-      {/* Est. Total — bold, color-coded */}
-      <div
-        role="cell"
-        className="font-bold text-[15px] text-right tabular-nums hidden sm:block"
-        style={{ color: priceColor(estAmount, priceRange) }}
+      {/* Est. Total */}
+      <td
+        className="py-2.5 px-4 text-right tabular-nums font-bold text-[15px] hidden sm:table-cell"
+        style={{
+          color: priceColor(estAmount, priceRange),
+          borderBottom: isExpanded ? "none" : "1px solid var(--cc-border)",
+        }}
       >
         {formatPrice(estAmount)}
-      </div>
+      </td>
 
       {/* Distance */}
-      <div
-        role="cell"
-        className="text-[12px] text-right"
-        style={{ color: "var(--cc-text-tertiary)" }}
+      <td
+        className="py-2.5 px-4 text-right text-[12px]"
+        style={{
+          color: "var(--cc-text-tertiary)",
+          borderBottom: isExpanded ? "none" : "1px solid var(--cc-border)",
+        }}
       >
         {distance}
-      </div>
+      </td>
 
-      {/* Quality stars — placeholder until #141 */}
-      <div
-        role="cell"
-        className="text-[12px] hidden sm:block"
-        style={{ color: "var(--cc-text-tertiary)" }}
+      {/* Quality */}
+      <td
+        className="py-2.5 px-4 text-[12px] hidden sm:table-cell"
+        style={{
+          color: "var(--cc-text-tertiary)",
+          borderBottom: isExpanded ? "none" : "1px solid var(--cc-border)",
+        }}
       >
         —
-      </div>
+      </td>
 
       {/* Chevron */}
-      <div role="cell" className="flex justify-center">
+      <td
+        className="py-2.5 pr-4 text-center"
+        style={{
+          borderBottom: isExpanded ? "none" : "1px solid var(--cc-border)",
+          width: "32px",
+        }}
+      >
         <svg
-          className="w-3.5 h-3.5 transition-transform duration-150"
+          className="w-3.5 h-3.5 transition-transform duration-150 inline-block"
           style={{
             color: isExpanded ? "var(--cc-primary)" : "var(--cc-border-strong)",
             transform: isExpanded ? "rotate(180deg)" : "rotate(0deg)",
@@ -146,9 +156,7 @@ export function ResultRow({
         >
           <polyline points="6 9 12 15 18 9" />
         </svg>
-      </div>
-    </div>
+      </td>
+    </tr>
   );
 }
-
-export { ROW_GRID, ROW_GAP };

--- a/components/ResultRow.tsx
+++ b/components/ResultRow.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import {
+  formatPrice,
+  formatDistance,
+  getDisplayPrice,
+  displayName,
+} from "@/lib/format";
+import type { ChargeResult } from "@/types";
+
+interface ResultRowProps {
+  result: ChargeResult;
+  rank: number;
+  isSelected?: boolean;
+  isExpanded?: boolean;
+  onToggleExpand?: () => void;
+  onSelect?: () => void;
+}
+
+const ROW_GRID = "1fr 90px 90px 65px 80px 24px";
+
+export function ResultRow({
+  result,
+  isSelected,
+  isExpanded,
+  onToggleExpand,
+  onSelect,
+}: ResultRowProps) {
+  const distance = formatDistance(result.distanceMiles);
+  const displayPrice = getDisplayPrice(result);
+  const estTotal =
+    result.estimatedTotalMedian ?? result.episodeEstimate?.estimatedAllInMedian;
+
+  return (
+    <div
+      data-result-id={result.id}
+      data-provider-id={result.provider.id}
+      className="grid items-center cursor-pointer select-none transition-colors duration-100 hover:bg-[var(--cc-surface-hover)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--cc-primary)]"
+      style={{
+        gridTemplateColumns: ROW_GRID,
+        padding: "10px 16px",
+        borderBottom: isExpanded ? "none" : "1px solid var(--cc-border)",
+        background:
+          isExpanded || isSelected ? "var(--cc-primary-light)" : undefined,
+      }}
+      role="row"
+      aria-expanded={isExpanded}
+      tabIndex={0}
+      onClick={() => {
+        onToggleExpand?.();
+        if (!isExpanded) onSelect?.();
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onToggleExpand?.();
+          if (!isExpanded) onSelect?.();
+        }
+      }}
+    >
+      {/* Provider */}
+      <div role="cell">
+        <div
+          className="font-semibold text-[13px] truncate"
+          style={{ color: "var(--cc-text)" }}
+        >
+          {displayName(result.provider.name)}
+        </div>
+        <div
+          className="text-[11px]"
+          style={{ color: "var(--cc-text-tertiary)" }}
+        >
+          {result.setting || "Outpatient"}
+        </div>
+      </div>
+
+      {/* Est. Total — primary number */}
+      <div
+        role="cell"
+        className="font-bold text-[15px] hidden sm:block"
+        style={{ color: "var(--cc-primary)" }}
+      >
+        {estTotal ? formatPrice(estTotal) : formatPrice(displayPrice.amount)}
+      </div>
+
+      {/* Base Price — secondary */}
+      <div
+        role="cell"
+        className="text-[13px] font-bold sm:font-normal"
+        style={{
+          color: isExpanded ? "var(--cc-primary)" : "var(--cc-text-secondary)",
+        }}
+      >
+        {formatPrice(displayPrice.amount)}
+      </div>
+
+      {/* Distance */}
+      <div
+        role="cell"
+        className="text-[12px]"
+        style={{ color: "var(--cc-text-tertiary)" }}
+      >
+        {distance}
+      </div>
+
+      {/* Quality stars — placeholder until #141 */}
+      <div
+        role="cell"
+        className="text-[12px] hidden sm:block"
+        style={{ color: "var(--cc-text-tertiary)" }}
+      >
+        —
+      </div>
+
+      {/* Chevron */}
+      <div role="cell" className="flex justify-center">
+        <svg
+          className="w-3.5 h-3.5 transition-transform duration-150"
+          style={{
+            color: isExpanded ? "var(--cc-primary)" : "var(--cc-border-strong)",
+            transform: isExpanded ? "rotate(180deg)" : "rotate(0deg)",
+          }}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </div>
+    </div>
+  );
+}
+
+export { ROW_GRID };

--- a/components/ResultRow.tsx
+++ b/components/ResultRow.tsx
@@ -76,7 +76,7 @@ export function ResultRow({
       }}
     >
       {/* Provider */}
-      <div role="cell">
+      <div role="cell" className="min-w-0">
         <div
           className="font-semibold text-[13px] truncate"
           style={{ color: "var(--cc-text)" }}

--- a/components/ResultRow.tsx
+++ b/components/ResultRow.tsx
@@ -10,7 +10,6 @@ import type { ChargeResult } from "@/types";
 
 interface ResultRowProps {
   result: ChargeResult;
-  rank: number;
   isSelected?: boolean;
   isExpanded?: boolean;
   onToggleExpand?: () => void;

--- a/components/ResultRow.tsx
+++ b/components/ResultRow.tsx
@@ -15,9 +15,22 @@ interface ResultRowProps {
   isExpanded?: boolean;
   onToggleExpand?: () => void;
   onSelect?: () => void;
+  priceRange?: { min: number; max: number };
 }
 
-const ROW_GRID = "1fr 90px 90px 65px 80px 24px";
+const ROW_GRID = "1fr 90px 100px 65px 80px 24px";
+
+/** Returns a color based on where the price falls in the range: green (low), amber (mid), red (high) */
+function priceColor(
+  price: number | undefined,
+  range: { min: number; max: number } | undefined
+): string {
+  if (!price || !range || range.max === range.min) return "var(--cc-text)";
+  const ratio = (price - range.min) / (range.max - range.min);
+  if (ratio <= 0.33) return "var(--cc-success)"; // green — low end
+  if (ratio <= 0.66) return "var(--cc-accent)"; // amber — mid
+  return "var(--cc-error)"; // red — high end
+}
 
 export function ResultRow({
   result,
@@ -25,11 +38,15 @@ export function ResultRow({
   isExpanded,
   onToggleExpand,
   onSelect,
+  priceRange,
 }: ResultRowProps) {
   const distance = formatDistance(result.distanceMiles);
   const displayPrice = getDisplayPrice(result);
   const estTotal =
     result.estimatedTotalMedian ?? result.episodeEstimate?.estimatedAllInMedian;
+
+  const baseAmount = displayPrice.amount;
+  const estAmount = estTotal ?? baseAmount;
 
   return (
     <div
@@ -74,24 +91,22 @@ export function ResultRow({
         </div>
       </div>
 
-      {/* Est. Total — primary number */}
+      {/* Base Price — first, normal weight */}
+      <div
+        role="cell"
+        className="text-[13px]"
+        style={{ color: priceColor(baseAmount, priceRange) }}
+      >
+        {formatPrice(baseAmount)}
+      </div>
+
+      {/* Est. Total — bold, color-coded */}
       <div
         role="cell"
         className="font-bold text-[15px] hidden sm:block"
-        style={{ color: "var(--cc-primary)" }}
+        style={{ color: priceColor(estAmount, priceRange) }}
       >
-        {estTotal ? formatPrice(estTotal) : formatPrice(displayPrice.amount)}
-      </div>
-
-      {/* Base Price — secondary */}
-      <div
-        role="cell"
-        className="text-[13px] font-bold sm:font-normal"
-        style={{
-          color: isExpanded ? "var(--cc-primary)" : "var(--cc-text-secondary)",
-        }}
-      >
-        {formatPrice(displayPrice.amount)}
+        {formatPrice(estAmount)}
       </div>
 
       {/* Distance */}

--- a/components/ResultRowDetail.tsx
+++ b/components/ResultRowDetail.tsx
@@ -31,153 +31,156 @@ export function ResultRowDetail({ result }: ResultRowDetailProps) {
         : null;
 
   return (
-    <div
-      style={{
-        background: "var(--cc-primary-light)",
-        borderBottom: "1px solid var(--cc-border)",
-      }}
-    >
-      <div
-        style={{ padding: "12px 16px" }}
-        className="flex flex-col sm:flex-row gap-4"
+    <tr>
+      <td
+        colSpan={6}
+        style={{
+          background: "var(--cc-primary-light)",
+          borderBottom: "1px solid var(--cc-border)",
+        }}
       >
-        {/* Left — fee breakdown */}
-        <div className="flex-1 min-w-0">
-          {address && (
-            <p
-              className="text-[12px] mb-2.5"
-              style={{ color: "var(--cc-text-secondary)" }}
-            >
-              {address}
-            </p>
-          )}
-
-          <div
-            className="rounded-md p-3"
-            style={{
-              background: "var(--cc-surface)",
-              border: "1px solid var(--cc-border)",
-            }}
-          >
-            <p
-              className="text-[10px] font-bold uppercase tracking-wider mb-2"
-              style={{ color: "var(--cc-text-tertiary)" }}
-            >
-              Fee Breakdown
-            </p>
-            <div className="flex justify-between py-1 text-[13px]">
-              <span style={{ color: "var(--cc-text-secondary)" }}>
-                {result.billingClass?.toLowerCase() === "professional"
-                  ? "Professional Fee"
-                  : "Facility Fee"}
-              </span>
-              <span
-                className="font-semibold"
-                style={{ color: "var(--cc-text)" }}
+        <div
+          style={{ padding: "12px 16px" }}
+          className="flex flex-col sm:flex-row gap-4"
+        >
+          {/* Left — fee breakdown */}
+          <div className="flex-1 min-w-0">
+            {address && (
+              <p
+                className="text-[12px] mb-2.5"
+                style={{ color: "var(--cc-text-secondary)" }}
               >
-                {formatPrice(displayPrice.amount)}
-              </span>
-            </div>
-            {billingClassNote && (
+                {address}
+              </p>
+            )}
+
+            <div
+              className="rounded-md p-3"
+              style={{
+                background: "var(--cc-surface)",
+                border: "1px solid var(--cc-border)",
+              }}
+            >
+              <p
+                className="text-[10px] font-bold uppercase tracking-wider mb-2"
+                style={{ color: "var(--cc-text-tertiary)" }}
+              >
+                Fee Breakdown
+              </p>
               <div className="flex justify-between py-1 text-[13px]">
                 <span style={{ color: "var(--cc-text-secondary)" }}>
-                  {result.billingClass?.toLowerCase() === "facility"
+                  {result.billingClass?.toLowerCase() === "professional"
                     ? "Professional Fee"
                     : "Facility Fee"}
                 </span>
                 <span
-                  className="text-[12px] italic"
-                  style={{ color: "var(--cc-accent)" }}
-                >
-                  Billed separately
-                </span>
-              </div>
-            )}
-            {estTotal != null && estTotal !== displayPrice.amount && (
-              <div
-                className="flex justify-between py-1.5 mt-1 text-[13px]"
-                style={{ borderTop: "1px solid var(--cc-border)" }}
-              >
-                <span
                   className="font-semibold"
                   style={{ color: "var(--cc-text)" }}
                 >
-                  Estimated Total
-                </span>
-                <span
-                  className="font-bold text-[15px]"
-                  style={{ color: "var(--cc-primary)" }}
-                >
-                  {formatPrice(estTotal)}
+                  {formatPrice(displayPrice.amount)}
                 </span>
               </div>
-            )}
-          </div>
-        </div>
-
-        {/* Right — meta + CTA */}
-        <div className="flex flex-col gap-2 justify-between sm:min-w-[170px]">
-          {result.medicareFacilityRate != null && (
-            <div className="text-[12px]">
-              <span style={{ color: "var(--cc-text-tertiary)" }}>
-                Medicare:{" "}
-              </span>
-              <span
-                className="font-semibold"
-                style={{ color: "var(--cc-success)" }}
-              >
-                {formatPrice(result.medicareFacilityRate)}
-              </span>
-              {result.medicareMultiplier != null &&
-                result.medicareMultiplier > 1 && (
-                  <span
-                    className="text-[10px] font-semibold px-1.5 py-0.5 rounded ml-1"
-                    style={{
-                      background: "var(--cc-accent-light)",
-                      color: "var(--cc-accent)",
-                    }}
-                  >
-                    {result.medicareMultiplier}×
+              {billingClassNote && (
+                <div className="flex justify-between py-1 text-[13px]">
+                  <span style={{ color: "var(--cc-text-secondary)" }}>
+                    {result.billingClass?.toLowerCase() === "facility"
+                      ? "Professional Fee"
+                      : "Facility Fee"}
                   </span>
-                )}
-            </div>
-          )}
-          {result.avgNegotiatedRate != null && (
-            <div className="text-[12px]">
-              <span style={{ color: "var(--cc-text-tertiary)" }}>
-                Avg Insured:{" "}
-              </span>
-              <span
-                className="font-semibold"
-                style={{ color: "var(--cc-info)" }}
-              >
-                {formatPrice(result.avgNegotiatedRate)}
-              </span>
-              {result.payerCount != null && result.payerCount > 0 && (
-                <span style={{ color: "var(--cc-text-tertiary)" }}>
-                  {" "}
-                  ({result.payerCount} payers)
-                </span>
+                  <span
+                    className="text-[12px] italic"
+                    style={{ color: "var(--cc-accent)" }}
+                  >
+                    Billed separately
+                  </span>
+                </div>
+              )}
+              {estTotal != null && estTotal !== displayPrice.amount && (
+                <div
+                  className="flex justify-between py-1.5 mt-1 text-[13px]"
+                  style={{ borderTop: "1px solid var(--cc-border)" }}
+                >
+                  <span
+                    className="font-semibold"
+                    style={{ color: "var(--cc-text)" }}
+                  >
+                    Estimated Total
+                  </span>
+                  <span
+                    className="font-bold text-[15px]"
+                    style={{ color: "var(--cc-primary)" }}
+                  >
+                    {formatPrice(estTotal)}
+                  </span>
+                </div>
               )}
             </div>
-          )}
-          <button
-            className="text-[12px] font-semibold px-3 py-1.5 rounded-md transition-colors mt-auto"
-            style={{
-              background: "var(--cc-surface)",
-              border: "1px solid var(--cc-primary)",
-              color: "var(--cc-primary)",
-            }}
-            onClick={(e) => {
-              e.stopPropagation();
-              // Placeholder — hospital profile page not yet built
-            }}
-            title="Coming soon"
-          >
-            View Hospital Profile →
-          </button>
+          </div>
+
+          {/* Right — meta + CTA */}
+          <div className="flex flex-col gap-2 justify-between sm:min-w-[170px]">
+            {result.medicareFacilityRate != null && (
+              <div className="text-[12px]">
+                <span style={{ color: "var(--cc-text-tertiary)" }}>
+                  Medicare:{" "}
+                </span>
+                <span
+                  className="font-semibold"
+                  style={{ color: "var(--cc-success)" }}
+                >
+                  {formatPrice(result.medicareFacilityRate)}
+                </span>
+                {result.medicareMultiplier != null &&
+                  result.medicareMultiplier > 1 && (
+                    <span
+                      className="text-[10px] font-semibold px-1.5 py-0.5 rounded ml-1"
+                      style={{
+                        background: "var(--cc-accent-light)",
+                        color: "var(--cc-accent)",
+                      }}
+                    >
+                      {result.medicareMultiplier}×
+                    </span>
+                  )}
+              </div>
+            )}
+            {result.avgNegotiatedRate != null && (
+              <div className="text-[12px]">
+                <span style={{ color: "var(--cc-text-tertiary)" }}>
+                  Avg Insured:{" "}
+                </span>
+                <span
+                  className="font-semibold"
+                  style={{ color: "var(--cc-info)" }}
+                >
+                  {formatPrice(result.avgNegotiatedRate)}
+                </span>
+                {result.payerCount != null && result.payerCount > 0 && (
+                  <span style={{ color: "var(--cc-text-tertiary)" }}>
+                    {" "}
+                    ({result.payerCount} payers)
+                  </span>
+                )}
+              </div>
+            )}
+            <button
+              className="text-[12px] font-semibold px-3 py-1.5 rounded-md transition-colors mt-auto"
+              style={{
+                background: "var(--cc-surface)",
+                border: "1px solid var(--cc-primary)",
+                color: "var(--cc-primary)",
+              }}
+              onClick={(e) => {
+                e.stopPropagation();
+                // Placeholder — hospital profile page not yet built
+              }}
+              title="Coming soon"
+            >
+              View Hospital Profile →
+            </button>
+          </div>
         </div>
-      </div>
-    </div>
+      </td>
+    </tr>
   );
 }

--- a/components/ResultRowDetail.tsx
+++ b/components/ResultRowDetail.tsx
@@ -1,14 +1,11 @@
 "use client";
 
-import { formatPrice, getDisplayPrice } from "@/lib/format";
+import { formatPrice, getDisplayPrice, notNull } from "@/lib/format";
 import type { ChargeResult } from "@/types";
 
 interface ResultRowDetailProps {
   result: ChargeResult;
 }
-
-const notNull = (v: string | undefined): v is string =>
-  !!v && v.toLowerCase() !== "null";
 
 export function ResultRowDetail({ result }: ResultRowDetailProps) {
   const displayPrice = getDisplayPrice(result);

--- a/components/ResultRowDetail.tsx
+++ b/components/ResultRowDetail.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { formatPrice, getDisplayPrice } from "@/lib/format";
+import type { ChargeResult } from "@/types";
+
+interface ResultRowDetailProps {
+  result: ChargeResult;
+}
+
+const notNull = (v: string | undefined): v is string =>
+  !!v && v.toLowerCase() !== "null";
+
+export function ResultRowDetail({ result }: ResultRowDetailProps) {
+  const displayPrice = getDisplayPrice(result);
+  const estTotal =
+    result.estimatedTotalMedian ?? result.episodeEstimate?.estimatedAllInMedian;
+
+  const address = [
+    result.provider.address,
+    result.provider.city,
+    [result.provider.state, result.provider.zip].filter(notNull).join(" "),
+  ]
+    .filter(notNull)
+    .join(", ");
+
+  const billingClassNote =
+    result.billingClass?.toLowerCase() === "facility"
+      ? "Facility fee only — professional fees may apply separately"
+      : result.billingClass?.toLowerCase() === "professional"
+        ? "Professional fee only — facility charges may apply separately"
+        : null;
+
+  return (
+    <div
+      style={{
+        background: "var(--cc-primary-light)",
+        borderBottom: "1px solid var(--cc-border)",
+      }}
+    >
+      <div
+        style={{ padding: "12px 16px" }}
+        className="flex flex-col sm:flex-row gap-4"
+      >
+        {/* Left — fee breakdown */}
+        <div className="flex-1 min-w-0">
+          {address && (
+            <p
+              className="text-[12px] mb-2.5"
+              style={{ color: "var(--cc-text-secondary)" }}
+            >
+              {address}
+            </p>
+          )}
+
+          <div
+            className="rounded-md p-3"
+            style={{
+              background: "var(--cc-surface)",
+              border: "1px solid var(--cc-border)",
+            }}
+          >
+            <p
+              className="text-[10px] font-bold uppercase tracking-wider mb-2"
+              style={{ color: "var(--cc-text-tertiary)" }}
+            >
+              Fee Breakdown
+            </p>
+            <div className="flex justify-between py-1 text-[13px]">
+              <span style={{ color: "var(--cc-text-secondary)" }}>
+                {result.billingClass?.toLowerCase() === "professional"
+                  ? "Professional Fee"
+                  : "Facility Fee"}
+              </span>
+              <span
+                className="font-semibold"
+                style={{ color: "var(--cc-text)" }}
+              >
+                {formatPrice(displayPrice.amount)}
+              </span>
+            </div>
+            {billingClassNote && (
+              <div className="flex justify-between py-1 text-[13px]">
+                <span style={{ color: "var(--cc-text-secondary)" }}>
+                  {result.billingClass?.toLowerCase() === "facility"
+                    ? "Professional Fee"
+                    : "Facility Fee"}
+                </span>
+                <span
+                  className="text-[12px] italic"
+                  style={{ color: "var(--cc-accent)" }}
+                >
+                  Billed separately
+                </span>
+              </div>
+            )}
+            {estTotal != null && estTotal !== displayPrice.amount && (
+              <div
+                className="flex justify-between py-1.5 mt-1 text-[13px]"
+                style={{ borderTop: "1px solid var(--cc-border)" }}
+              >
+                <span
+                  className="font-semibold"
+                  style={{ color: "var(--cc-text)" }}
+                >
+                  Estimated Total
+                </span>
+                <span
+                  className="font-bold text-[15px]"
+                  style={{ color: "var(--cc-primary)" }}
+                >
+                  {formatPrice(estTotal)}
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Right — meta + CTA */}
+        <div className="flex flex-col gap-2 justify-between sm:min-w-[170px]">
+          {result.medicareFacilityRate != null && (
+            <div className="text-[12px]">
+              <span style={{ color: "var(--cc-text-tertiary)" }}>
+                Medicare:{" "}
+              </span>
+              <span
+                className="font-semibold"
+                style={{ color: "var(--cc-success)" }}
+              >
+                {formatPrice(result.medicareFacilityRate)}
+              </span>
+              {result.medicareMultiplier != null &&
+                result.medicareMultiplier > 1 && (
+                  <span
+                    className="text-[10px] font-semibold px-1.5 py-0.5 rounded ml-1"
+                    style={{
+                      background: "var(--cc-accent-light)",
+                      color: "var(--cc-accent)",
+                    }}
+                  >
+                    {result.medicareMultiplier}×
+                  </span>
+                )}
+            </div>
+          )}
+          {result.avgNegotiatedRate != null && (
+            <div className="text-[12px]">
+              <span style={{ color: "var(--cc-text-tertiary)" }}>
+                Avg Insured:{" "}
+              </span>
+              <span
+                className="font-semibold"
+                style={{ color: "var(--cc-info)" }}
+              >
+                {formatPrice(result.avgNegotiatedRate)}
+              </span>
+              {result.payerCount != null && result.payerCount > 0 && (
+                <span style={{ color: "var(--cc-text-tertiary)" }}>
+                  {" "}
+                  ({result.payerCount} payers)
+                </span>
+              )}
+            </div>
+          )}
+          <button
+            className="text-[12px] font-semibold px-3 py-1.5 rounded-md transition-colors mt-auto"
+            style={{
+              background: "var(--cc-surface)",
+              border: "1px solid var(--cc-primary)",
+              color: "var(--cc-primary)",
+            }}
+            onClick={(e) => {
+              e.stopPropagation();
+              // Placeholder — hospital profile page not yet built
+            }}
+            title="Coming soon"
+          >
+            View Hospital Profile →
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/ResultsList.tsx
+++ b/components/ResultsList.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import type { ChargeResult } from "@/types";
+import { getDisplayPrice } from "@/lib/format";
 import { ResultRow, ROW_GRID } from "./ResultRow";
 import { ResultRowDetail } from "./ResultRowDetail";
 
@@ -61,6 +62,22 @@ export function ResultsList({
       prev.has(id) ? new Set<string>() : new Set([id])
     );
   }, []);
+
+  // Compute price range for color-coding (green/amber/red)
+  const priceRange = useMemo(() => {
+    const prices = results
+      .map((r) => {
+        const dp = getDisplayPrice(r);
+        return (
+          r.estimatedTotalMedian ??
+          r.episodeEstimate?.estimatedAllInMedian ??
+          dp.amount
+        );
+      })
+      .filter((p): p is number => p != null && p > 0);
+    if (prices.length === 0) return undefined;
+    return { min: Math.min(...prices), max: Math.max(...prices) };
+  }, [results]);
 
   if (loading) {
     return (
@@ -209,10 +226,10 @@ export function ResultsList({
         }}
       >
         <span role="columnheader">Provider</span>
+        <span role="columnheader">Base Price</span>
         <span role="columnheader" className="hidden sm:block">
           Est. Total
         </span>
-        <span role="columnheader">Base Price</span>
         <span role="columnheader">Distance</span>
         <span role="columnheader" className="hidden sm:block">
           Quality
@@ -233,6 +250,7 @@ export function ResultsList({
               onCardSelect?.(result.provider.id);
               onResultClick?.();
             }}
+            priceRange={priceRange}
           />
           {expandedIds.has(result.id) && <ResultRowDetail result={result} />}
         </div>

--- a/components/ResultsList.tsx
+++ b/components/ResultsList.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState, useCallback, useEffect, useMemo } from "react";
+import React, { useState, useCallback, useEffect, useMemo } from "react";
 import type { ChargeResult } from "@/types";
 import { getDisplayPrice } from "@/lib/format";
-import { ResultRow, ROW_GRID, ROW_GAP } from "./ResultRow";
+import { ResultRow } from "./ResultRow";
 import { ResultRowDetail } from "./ResultRowDetail";
 
 interface ResultsListProps {
@@ -81,45 +81,67 @@ export function ResultsList({
 
   if (loading) {
     return (
-      <div>
-        {/* Skeleton column headers */}
-        <div
-          className="grid items-center"
-          style={{
-            gridTemplateColumns: ROW_GRID,
-            gap: ROW_GAP,
-            padding: "6px 16px",
-            borderBottom: "1px solid var(--cc-border)",
-          }}
-        >
-          {["w-16", "w-12", "w-12", "w-10", "w-10", "w-4"].map((w, i) => (
-            <div key={i} className={`h-2.5 ${w} shimmer rounded`} />
+      <table className="w-full" style={{ borderCollapse: "collapse" }}>
+        <thead>
+          <tr>
+            {["w-16", "w-12", "w-12", "w-10", "w-10", "w-4"].map((w, i) => (
+              <th
+                key={i}
+                className="py-1.5 px-4"
+                style={{ borderBottom: "1px solid var(--cc-border)" }}
+              >
+                <div className={`h-2.5 ${w} shimmer rounded`} />
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
+            <tr key={i}>
+              <td
+                className="py-3 px-4"
+                style={{ borderBottom: "1px solid var(--cc-border)" }}
+              >
+                <div className="h-3.5 w-40 shimmer rounded mb-1" />
+                <div className="h-2.5 w-16 shimmer rounded" />
+              </td>
+              <td
+                className="py-3 px-4"
+                style={{ borderBottom: "1px solid var(--cc-border)" }}
+              >
+                <div className="h-4 w-14 shimmer rounded" />
+              </td>
+              <td
+                className="py-3 px-4 hidden sm:table-cell"
+                style={{ borderBottom: "1px solid var(--cc-border)" }}
+              >
+                <div className="h-4 w-16 shimmer rounded" />
+              </td>
+              <td
+                className="py-3 px-4"
+                style={{ borderBottom: "1px solid var(--cc-border)" }}
+              >
+                <div className="h-3 w-10 shimmer rounded" />
+              </td>
+              <td
+                className="py-3 px-4 hidden sm:table-cell"
+                style={{ borderBottom: "1px solid var(--cc-border)" }}
+              >
+                <div className="h-3 w-14 shimmer rounded" />
+              </td>
+              <td
+                className="py-3 pr-4"
+                style={{
+                  borderBottom: "1px solid var(--cc-border)",
+                  width: "32px",
+                }}
+              >
+                <div className="h-3 w-3 shimmer rounded" />
+              </td>
+            </tr>
           ))}
-        </div>
-        {/* Skeleton rows */}
-        {[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
-          <div
-            key={i}
-            className="grid items-center"
-            style={{
-              gridTemplateColumns: ROW_GRID,
-              gap: ROW_GAP,
-              padding: "12px 16px",
-              borderBottom: "1px solid var(--cc-border)",
-            }}
-          >
-            <div>
-              <div className="h-3.5 w-40 shimmer rounded mb-1" />
-              <div className="h-2.5 w-16 shimmer rounded" />
-            </div>
-            <div className="h-4 w-14 shimmer rounded hidden sm:block" />
-            <div className="h-4 w-12 shimmer rounded" />
-            <div className="h-3 w-10 shimmer rounded" />
-            <div className="h-3 w-14 shimmer rounded hidden sm:block" />
-            <div className="h-3 w-3 shimmer rounded" />
-          </div>
-        ))}
-      </div>
+        </tbody>
+      </table>
     );
   }
 
@@ -204,56 +226,80 @@ export function ResultsList({
         </div>
       )}
 
-      {/* Column headers */}
-      <div
-        className="grid items-center sticky top-0 z-10"
-        role="row"
-        style={{
-          gridTemplateColumns: ROW_GRID,
-          padding: "6px 16px",
-          borderBottom: "1px solid var(--cc-border)",
-          background: "var(--cc-bg)",
-          fontSize: "10px",
-          fontWeight: 600,
-          textTransform: "uppercase" as const,
-          letterSpacing: "0.08em",
-          color: "var(--cc-text-tertiary)",
-        }}
-      >
-        <span role="columnheader">Provider</span>
-        <span role="columnheader" className="text-right">
-          Base Price
-        </span>
-        <span role="columnheader" className="text-right hidden sm:block">
-          Est. Total
-        </span>
-        <span role="columnheader" className="text-right">
-          Distance
-        </span>
-        <span role="columnheader" className="text-right hidden sm:block">
-          Quality
-        </span>
-        <span />
-      </div>
-
-      {/* Result rows */}
-      {results.map((result, i) => (
-        <div key={result.id}>
-          <ResultRow
-            result={result}
-            rank={i + 1}
-            isSelected={result.provider.id === selectedProviderId}
-            isExpanded={expandedIds.has(result.id)}
-            onToggleExpand={() => handleToggleExpand(result.id)}
-            onSelect={() => {
-              onCardSelect?.(result.provider.id);
-              onResultClick?.();
+      <table className="w-full" style={{ borderCollapse: "collapse" }}>
+        <thead
+          className="sticky top-0 z-10"
+          style={{ background: "var(--cc-bg)" }}
+        >
+          <tr
+            style={{
+              fontSize: "10px",
+              fontWeight: 600,
+              textTransform: "uppercase" as const,
+              letterSpacing: "0.08em",
+              color: "var(--cc-text-tertiary)",
             }}
-            priceRange={priceRange}
-          />
-          {expandedIds.has(result.id) && <ResultRowDetail result={result} />}
-        </div>
-      ))}
+          >
+            <th
+              className="text-left py-1.5 px-4 font-semibold"
+              style={{ borderBottom: "1px solid var(--cc-border)" }}
+            >
+              Provider
+            </th>
+            <th
+              className="text-right py-1.5 px-4 font-semibold"
+              style={{ borderBottom: "1px solid var(--cc-border)" }}
+            >
+              Base Price
+            </th>
+            <th
+              className="text-right py-1.5 px-4 font-semibold hidden sm:table-cell"
+              style={{ borderBottom: "1px solid var(--cc-border)" }}
+            >
+              Est. Total
+            </th>
+            <th
+              className="text-right py-1.5 px-4 font-semibold"
+              style={{ borderBottom: "1px solid var(--cc-border)" }}
+            >
+              Distance
+            </th>
+            <th
+              className="py-1.5 px-4 font-semibold hidden sm:table-cell"
+              style={{ borderBottom: "1px solid var(--cc-border)" }}
+            >
+              Quality
+            </th>
+            <th
+              style={{
+                borderBottom: "1px solid var(--cc-border)",
+                width: "32px",
+              }}
+            />
+          </tr>
+        </thead>
+        <tbody>
+          {results.map((result, i) => (
+            <React.Fragment key={result.id}>
+              <ResultRow
+                result={result}
+                rank={i + 1}
+                isSelected={result.provider.id === selectedProviderId}
+                isExpanded={expandedIds.has(result.id)}
+                onToggleExpand={() => handleToggleExpand(result.id)}
+                onSelect={() => {
+                  onCardSelect?.(result.provider.id);
+                  onResultClick?.();
+                }}
+                priceRange={priceRange}
+              />
+              {expandedIds.has(result.id) && (
+                <ResultRowDetail result={result} />
+              )}
+            </React.Fragment>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/components/ResultsList.tsx
+++ b/components/ResultsList.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useCallback, useEffect } from "react";
 import type { ChargeResult } from "@/types";
-import { ResultCard } from "./ResultCard";
+import { ResultRow, ROW_GRID } from "./ResultRow";
+import { ResultRowDetail } from "./ResultRowDetail";
 
 interface ResultsListProps {
   results: ChargeResult[];
@@ -23,7 +24,6 @@ export function ResultsList({
   markerClickCount = 0,
   onCardSelect,
   onResultClick,
-  codeDescriptionMap,
   locationDisplay,
   onExpandRadius,
 }: ResultsListProps) {
@@ -64,27 +64,40 @@ export function ResultsList({
 
   if (loading) {
     return (
-      <div className="space-y-1.5">
+      <div>
+        {/* Skeleton column headers */}
+        <div
+          className="grid items-center"
+          style={{
+            gridTemplateColumns: ROW_GRID,
+            padding: "6px 16px",
+            borderBottom: "1px solid var(--cc-border)",
+          }}
+        >
+          {["w-16", "w-12", "w-12", "w-10", "w-10", "w-4"].map((w, i) => (
+            <div key={i} className={`h-2.5 ${w} shimmer rounded`} />
+          ))}
+        </div>
+        {/* Skeleton rows */}
         {[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
           <div
             key={i}
-            className="rounded-xl border overflow-hidden"
+            className="grid items-center"
             style={{
-              background: "var(--cc-surface)",
-              borderColor: "var(--cc-border)",
+              gridTemplateColumns: ROW_GRID,
+              padding: "12px 16px",
+              borderBottom: "1px solid var(--cc-border)",
             }}
           >
-            <div className="flex">
-              <div className="w-1 shrink-0 shimmer" />
-              <div className="flex-1 flex items-center gap-2 px-3 py-2">
-                <div className="w-5 h-5 rounded-lg shimmer shrink-0" />
-                <div className="h-4 w-40 shimmer" />
-                <div className="flex-1" />
-                <div className="h-4 w-16 shimmer shrink-0" />
-                <div className="h-3 w-12 shimmer shrink-0 hidden sm:block" />
-                <div className="w-4 h-4 shimmer shrink-0 rounded" />
-              </div>
+            <div>
+              <div className="h-3.5 w-40 shimmer rounded mb-1" />
+              <div className="h-2.5 w-16 shimmer rounded" />
             </div>
+            <div className="h-4 w-14 shimmer rounded hidden sm:block" />
+            <div className="h-4 w-12 shimmer rounded" />
+            <div className="h-3 w-10 shimmer rounded" />
+            <div className="h-3 w-14 shimmer rounded hidden sm:block" />
+            <div className="h-3 w-3 shimmer rounded" />
           </div>
         ))}
       </div>
@@ -143,14 +156,17 @@ export function ResultsList({
   }
 
   return (
-    <div className="space-y-1.5">
-      <p className="text-sm" style={{ color: "var(--cc-text-tertiary)" }}>
+    <div>
+      <p
+        className="text-sm px-4 py-1"
+        style={{ color: "var(--cc-text-tertiary)" }}
+      >
         {results.length} result{results.length !== 1 ? "s" : ""} found
       </p>
 
       {results.length < 3 && (
         <div
-          className="p-3 rounded-xl border text-sm flex items-center justify-between gap-3"
+          className="mx-4 mb-2 p-3 rounded-lg border text-sm flex items-center justify-between gap-3"
           style={{
             background: "var(--cc-accent-light)",
             borderColor: "rgba(217, 119, 6, 0.2)",
@@ -158,9 +174,8 @@ export function ResultsList({
           }}
         >
           <span>
-            Only {results.length} result{results.length !== 1 ? "s" : ""} found
-            within your search radius. Try expanding your search area for more
-            options.
+            Only {results.length} result{results.length !== 1 ? "s" : ""} found.
+            Try expanding your search area.
           </span>
           {onExpandRadius && (
             <button
@@ -177,13 +192,38 @@ export function ResultsList({
         </div>
       )}
 
+      {/* Column headers */}
+      <div
+        className="grid items-center sticky top-0 z-10"
+        role="row"
+        style={{
+          gridTemplateColumns: ROW_GRID,
+          padding: "6px 16px",
+          borderBottom: "1px solid var(--cc-border)",
+          background: "var(--cc-bg)",
+          fontSize: "10px",
+          fontWeight: 600,
+          textTransform: "uppercase" as const,
+          letterSpacing: "0.08em",
+          color: "var(--cc-text-tertiary)",
+        }}
+      >
+        <span role="columnheader">Provider</span>
+        <span role="columnheader" className="hidden sm:block">
+          Est. Total
+        </span>
+        <span role="columnheader">Base Price</span>
+        <span role="columnheader">Distance</span>
+        <span role="columnheader" className="hidden sm:block">
+          Quality
+        </span>
+        <span />
+      </div>
+
+      {/* Result rows */}
       {results.map((result, i) => (
-        <div
-          key={result.id}
-          className="animate-fade-up"
-          style={{ animationDelay: `${Math.min(i, 10) * 0.04}s` }}
-        >
-          <ResultCard
+        <div key={result.id}>
+          <ResultRow
             result={result}
             rank={i + 1}
             isSelected={result.provider.id === selectedProviderId}
@@ -193,8 +233,8 @@ export function ResultsList({
               onCardSelect?.(result.provider.id);
               onResultClick?.();
             }}
-            codeDescriptionMap={codeDescriptionMap}
           />
+          {expandedIds.has(result.id) && <ResultRowDetail result={result} />}
         </div>
       ))}
     </div>

--- a/components/ResultsList.tsx
+++ b/components/ResultsList.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback, useEffect, useMemo } from "react";
 import type { ChargeResult } from "@/types";
 import { getDisplayPrice } from "@/lib/format";
-import { ResultRow, ROW_GRID } from "./ResultRow";
+import { ResultRow, ROW_GRID, ROW_GAP } from "./ResultRow";
 import { ResultRowDetail } from "./ResultRowDetail";
 
 interface ResultsListProps {
@@ -87,6 +87,7 @@ export function ResultsList({
           className="grid items-center"
           style={{
             gridTemplateColumns: ROW_GRID,
+            gap: ROW_GAP,
             padding: "6px 16px",
             borderBottom: "1px solid var(--cc-border)",
           }}
@@ -102,6 +103,7 @@ export function ResultsList({
             className="grid items-center"
             style={{
               gridTemplateColumns: ROW_GRID,
+              gap: ROW_GAP,
               padding: "12px 16px",
               borderBottom: "1px solid var(--cc-border)",
             }}

--- a/components/ResultsList.tsx
+++ b/components/ResultsList.tsx
@@ -174,13 +174,6 @@ export function ResultsList({
 
   return (
     <div>
-      <p
-        className="text-sm px-4 py-1"
-        style={{ color: "var(--cc-text-tertiary)" }}
-      >
-        {results.length} result{results.length !== 1 ? "s" : ""} found
-      </p>
-
       {results.length < 3 && (
         <div
           className="mx-4 mb-2 p-3 rounded-lg border text-sm flex items-center justify-between gap-3"

--- a/components/ResultsList.tsx
+++ b/components/ResultsList.tsx
@@ -13,7 +13,6 @@ interface ResultsListProps {
   markerClickCount?: number;
   onCardSelect?: (providerId: string) => void;
   onResultClick?: () => void;
-  codeDescriptionMap?: Record<string, string>;
   locationDisplay?: string;
   onExpandRadius?: () => void;
 }
@@ -62,6 +61,14 @@ export function ResultsList({
       prev.has(id) ? new Set<string>() : new Set([id])
     );
   }, []);
+
+  const handleSelect = useCallback(
+    (providerId: string) => {
+      onCardSelect?.(providerId);
+      onResultClick?.();
+    },
+    [onCardSelect, onResultClick]
+  );
 
   // Compute price range for color-coding (green/amber/red)
   const priceRange = useMemo(() => {
@@ -279,18 +286,14 @@ export function ResultsList({
           </tr>
         </thead>
         <tbody>
-          {results.map((result, i) => (
+          {results.map((result) => (
             <React.Fragment key={result.id}>
               <ResultRow
                 result={result}
-                rank={i + 1}
                 isSelected={result.provider.id === selectedProviderId}
                 isExpanded={expandedIds.has(result.id)}
                 onToggleExpand={() => handleToggleExpand(result.id)}
-                onSelect={() => {
-                  onCardSelect?.(result.provider.id);
-                  onResultClick?.();
-                }}
+                onSelect={() => handleSelect(result.provider.id)}
                 priceRange={priceRange}
               />
               {expandedIds.has(result.id) && (

--- a/components/ResultsList.tsx
+++ b/components/ResultsList.tsx
@@ -221,12 +221,16 @@ export function ResultsList({
         }}
       >
         <span role="columnheader">Provider</span>
-        <span role="columnheader">Base Price</span>
-        <span role="columnheader" className="hidden sm:block">
+        <span role="columnheader" className="text-right">
+          Base Price
+        </span>
+        <span role="columnheader" className="text-right hidden sm:block">
           Est. Total
         </span>
-        <span role="columnheader">Distance</span>
-        <span role="columnheader" className="hidden sm:block">
+        <span role="columnheader" className="text-right">
+          Distance
+        </span>
+        <span role="columnheader" className="text-right hidden sm:block">
           Quality
         </span>
         <span />

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -210,7 +210,7 @@ export function SearchBar({
         />
 
         <div
-          className={`flex items-center ${compact ? "px-3 sm:w-44" : "px-4 sm:w-44"}`}
+          className={`flex items-center ${compact ? "px-3 sm:w-52" : "px-4 sm:w-52"}`}
         >
           <svg
             className={`${compact ? "w-3.5 h-3.5 mr-1.5" : "w-4 h-4 mr-2"} shrink-0`}

--- a/components/landing/SearchCategories.tsx
+++ b/components/landing/SearchCategories.tsx
@@ -136,7 +136,7 @@ export function SearchCategories() {
       className="border-t px-4 py-16 sm:py-20"
       style={{
         borderColor: "var(--cc-border)",
-        background: "var(--cc-bg)",
+        background: "var(--cc-surface)",
       }}
     >
       <div className="max-w-5xl mx-auto">

--- a/docs/superpowers/plans/2026-03-25-results-ux-overhaul.md
+++ b/docs/superpowers/plans/2026-03-25-results-ux-overhaul.md
@@ -107,15 +107,7 @@ export function ResultRow({
         onToggleExpand?.();
         if (!isExpanded) onSelect?.();
       }}
-      onMouseEnter={(e) => {
-        if (!isExpanded && !isSelected)
-          (e.currentTarget as HTMLElement).style.background =
-            "var(--cc-surface-hover)";
-      }}
-      onMouseLeave={(e) => {
-        if (!isExpanded && !isSelected)
-          (e.currentTarget as HTMLElement).style.background = "transparent";
-      }}
+      className="grid items-center cursor-pointer select-none transition-colors duration-100 hover:bg-[var(--cc-surface-hover)]"
     >
       {/* Provider */}
       <div>
@@ -646,6 +638,98 @@ git commit -m "feat: mobile responsive adjustments for table layout"
 
 ---
 
+## Task 8: Component Tests
+
+**Files:**
+
+- Create: `__tests__/components/ResultRow.test.tsx`
+- Create: `__tests__/components/ResultRowDetail.test.tsx`
+
+Install React Testing Library if not present: `npm install -D @testing-library/react @testing-library/jest-dom`
+
+- [ ] **Step 1: Install test dependencies**
+
+Run: `npm install -D @testing-library/react @testing-library/jest-dom`
+
+- [ ] **Step 2: Write ResultRow tests**
+
+Test cases:
+
+- Renders provider name, est total, base price, distance
+- Shows estTotal in primary color when present
+- Falls back to displayPrice.amount when estTotal is null
+- Shows primary-light background when expanded
+- Shows primary-light background when selected
+- Calls onToggleExpand and onSelect on click
+- Truncates long provider names
+
+- [ ] **Step 3: Write ResultRowDetail tests**
+
+Test cases:
+
+- Renders address from provider fields, skipping null segments
+- Shows facility fee label + price for billingClass="facility"
+- Shows "Billed separately" note for the other fee type
+- Hides billing class callout when billingClass is null
+- Shows Medicare rate + multiplier badge when present
+- Hides Medicare row when medicareFacilityRate is null
+- Shows avg insured rate + payer count when present
+- Hides insured row when avgNegotiatedRate is null
+- Shows estimated total when different from base price
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm test`
+Expected: All new tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add __tests__/components/ package.json package-lock.json
+git commit -m "test: add component tests for ResultRow and ResultRowDetail"
+```
+
+---
+
+## Design Specs (from /plan-design-review)
+
+### Interaction States
+
+| Feature           | Loading                                                                    | Empty                                                                                                                            | Error                                                      | Partial Data                                                                                        |
+| ----------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Results table     | Grid skeleton: 8 rows matching column grid, shimmer animation on each cell | Centered message: "No results found near [location]" + search icon + "Try a larger radius or different location" + Expand button | "Unable to load results. Please try again." + retry button | N/A                                                                                                 |
+| Est. Total column | Shimmer bar                                                                | N/A                                                                                                                              | N/A                                                        | If no estimatedTotalMedian: show base displayPrice in primary color (same column, no fallback text) |
+| Quality column    | Shimmer bar                                                                | N/A                                                                                                                              | N/A                                                        | Show "—" for unrated (placeholder until #141)                                                       |
+| Row expansion     | N/A                                                                        | N/A                                                                                                                              | N/A                                                        | Hide Medicare row if null, hide insured row if null, hide Est. Total line if same as base price     |
+| Search in navbar  | Spinner on search button                                                   | N/A                                                                                                                              | Red border on input + validation message below             | N/A                                                                                                 |
+
+### Accessibility
+
+- Column headers: `role="columnheader"` on each header cell
+- Result rows: `role="row"` with `aria-expanded` on each expandable row
+- Cells: `role="cell"` on each data cell in the grid
+- Keyboard: rows are focusable (`tabIndex={0}`), Enter/Space toggles expand
+- Touch targets: minimum 44px row height (current 10px padding + content achieves this)
+- Focus visible: `focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--cc-primary)]`
+
+### Mobile Responsive (< 640px)
+
+**Columns:** Provider + Base Price + Distance + Chevron (hide Est. Total and Quality)
+
+- Grid: `1fr 80px 60px 24px`
+- Column headers update to match (hide hidden column headers)
+
+**Expanded detail:** Stacks vertically (flex-col instead of flex-row)
+
+- Fee breakdown takes full width
+- Medicare/insured/CTA stack below, also full width
+
+**Interpretation in nav:** Show only code pill (`CPT 71046`) on mobile, full "Interpreted as: ..." on desktop. Code pill is tappable to expand full text.
+
+**Hospital Profile button:** Shows tooltip "Coming soon" on click (placeholder until hospital profile page is built). Button styled as secondary/outlined.
+
+---
+
 ## Execution Notes
 
 **What's NOT in scope:**
@@ -663,3 +747,14 @@ git commit -m "feat: mobile responsive adjustments for table layout"
 - MEDIUM: Mobile responsive — need to test thoroughly since we're changing from cards to table rows
 
 **Estimated effort:** ~45 min CC time
+
+## GSTACK REVIEW REPORT
+
+| Review        | Trigger               | Why                             | Runs | Status | Findings                                                                                          |
+| ------------- | --------------------- | ------------------------------- | ---- | ------ | ------------------------------------------------------------------------------------------------- |
+| CEO Review    | `/plan-ceo-review`    | Scope & strategy                | 0    | —      | —                                                                                                 |
+| Codex Review  | `/codex review`       | Independent 2nd opinion         | 0    | —      | —                                                                                                 |
+| Eng Review    | `/plan-eng-review`    | Architecture & tests (required) | 1    | CLEAR  | 1 issue (JS hover → CSS hover), 0 critical gaps, full component tests added                       |
+| Design Review | `/plan-design-review` | UI/UX gaps                      | 1    | CLEAR  | score: 6/10 → 8/10, 6 decisions added (interaction states, a11y, mobile, hospital profile button) |
+
+**VERDICT:** ENG + DESIGN CLEARED — ready to implement.

--- a/docs/superpowers/plans/2026-03-25-results-ux-overhaul.md
+++ b/docs/superpowers/plans/2026-03-25-results-ux-overhaul.md
@@ -1,0 +1,665 @@
+# Results UX Overhaul Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the cluttered accordion-card results layout with a clean table-style split view, integrate search into the nav bar, and show Est. Total as the primary price.
+
+**Architecture:** The overhaul rewrites 3 components (ResultCard → ResultRow, Navbar, results page layout) and adjusts 2 others (FilterBar, SearchBar). The data layer (types, API, hooks) is unchanged — this is purely a presentation overhaul. The key structural change is moving from flex-based accordion cards to a grid-based table layout with progressive disclosure. **Task ordering: Tasks 1-4 are independent. Task 5 depends on Task 4. Task 6 depends on Task 5. Task 7 depends on Task 6.** For the navbar search integration, the approach is a React Context provider pattern — results page writes search state into context, Navbar reads from it.
+
+**Tech Stack:** Next.js 16 (App Router), React 19, Tailwind CSS v4, existing CSS variables from globals.css
+
+**Reference:** HTML prototype at `/tmp/clearcost-results-prototype.html`, GitHub issue #142
+
+---
+
+## File Structure
+
+### Files to Create
+
+| File                             | Responsibility                                                       |
+| -------------------------------- | -------------------------------------------------------------------- |
+| `components/ResultRow.tsx`       | New table-row result component (replaces ResultCard in results view) |
+| `components/ResultRowDetail.tsx` | Expanded detail panel (fee breakdown, Medicare, profile link)        |
+
+### Files to Modify
+
+| File                         | Change                                                                  |
+| ---------------------------- | ----------------------------------------------------------------------- |
+| `components/Navbar.tsx`      | Add search bar + interpretation inline                                  |
+| `components/ResultsList.tsx` | Switch from cards to table rows, add column headers                     |
+| `components/FilterBar.tsx`   | Compact the layout (smaller selects, tighter spacing)                   |
+| `components/SearchBar.tsx`   | Add `inline` variant for navbar integration                             |
+| `app/results/page.tsx`       | Change split to 50/50, move search to nav, remove interpretation banner |
+
+### Files to Keep (no changes)
+
+| File                                 | Why                                                                            |
+| ------------------------------------ | ------------------------------------------------------------------------------ |
+| `components/ResultCard.tsx`          | Keep for now — still used in mobile and potentially other views. Don't delete. |
+| `components/MapView.tsx`             | Map works as-is, just needs more space (handled by page layout change)         |
+| `types/index.ts`                     | Data types are unchanged                                                       |
+| `lib/cpt/*`, `lib/kb/*`, `app/api/*` | Backend is unchanged                                                           |
+
+---
+
+## Task 1: Create ResultRow Component (Collapsed State)
+
+**Files:**
+
+- Create: `components/ResultRow.tsx`
+
+The new table-row component replaces ResultCard's collapsed state. Grid-based, scannable, with Est. Total as the primary highlighted price.
+
+- [ ] **Step 1: Create ResultRow with grid layout**
+
+```tsx
+// components/ResultRow.tsx
+"use client";
+
+import {
+  formatPrice,
+  formatDistance,
+  getDisplayPrice,
+  displayName,
+} from "@/lib/format";
+import type { ChargeResult } from "@/types";
+
+interface ResultRowProps {
+  result: ChargeResult;
+  rank: number;
+  isSelected?: boolean;
+  isExpanded?: boolean;
+  onToggleExpand?: () => void;
+  onSelect?: () => void;
+}
+
+export function ResultRow({
+  result,
+  rank,
+  isSelected,
+  isExpanded,
+  onToggleExpand,
+  onSelect,
+}: ResultRowProps) {
+  const distance = formatDistance(result.distanceMiles);
+  const displayPrice = getDisplayPrice(result);
+  const estTotal =
+    result.estimatedTotalMedian ?? result.episodeEstimate?.estimatedAllInMedian;
+
+  return (
+    <div
+      data-result-id={result.id}
+      data-provider-id={result.provider.id}
+      className="grid items-center cursor-pointer select-none transition-colors duration-100"
+      style={{
+        gridTemplateColumns: "1fr 90px 90px 65px 80px 24px",
+        padding: "10px 16px",
+        borderBottom: isExpanded ? "none" : "1px solid var(--cc-border)",
+        background: isExpanded
+          ? "var(--cc-primary-light)"
+          : isSelected
+            ? "var(--cc-primary-light)"
+            : "transparent",
+      }}
+      role="button"
+      aria-expanded={isExpanded}
+      onClick={() => {
+        onToggleExpand?.();
+        if (!isExpanded) onSelect?.();
+      }}
+      onMouseEnter={(e) => {
+        if (!isExpanded && !isSelected)
+          (e.currentTarget as HTMLElement).style.background =
+            "var(--cc-surface-hover)";
+      }}
+      onMouseLeave={(e) => {
+        if (!isExpanded && !isSelected)
+          (e.currentTarget as HTMLElement).style.background = "transparent";
+      }}
+    >
+      {/* Provider */}
+      <div>
+        <div
+          className="font-semibold text-[13px] truncate"
+          style={{ color: "var(--cc-text)" }}
+        >
+          {displayName(result.provider.name)}
+        </div>
+        <div
+          className="text-[11px]"
+          style={{ color: "var(--cc-text-tertiary)" }}
+        >
+          {result.setting || "Outpatient"}
+        </div>
+      </div>
+
+      {/* Est. Total — primary number */}
+      <div
+        className="font-bold text-[15px]"
+        style={{ color: "var(--cc-primary)" }}
+      >
+        {estTotal ? formatPrice(estTotal) : formatPrice(displayPrice.amount)}
+      </div>
+
+      {/* Base Price — secondary */}
+      <div
+        className="text-[13px]"
+        style={{ color: "var(--cc-text-secondary)" }}
+      >
+        {formatPrice(displayPrice.amount)}
+      </div>
+
+      {/* Distance */}
+      <div className="text-[12px]" style={{ color: "var(--cc-text-tertiary)" }}>
+        {distance}
+      </div>
+
+      {/* Quality stars — placeholder until #141 */}
+      <div className="text-[12px]" style={{ color: "var(--cc-text-tertiary)" }}>
+        —
+      </div>
+
+      {/* Chevron */}
+      <svg
+        className="w-3.5 h-3.5 transition-transform duration-150"
+        style={{
+          color: isExpanded ? "var(--cc-primary)" : "var(--cc-border-strong)",
+          transform: isExpanded ? "rotate(180deg)" : "rotate(0deg)",
+        }}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <polyline points="6 9 12 15 18 9" />
+      </svg>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/ResultRow.tsx
+git commit -m "feat: add ResultRow table-style component for results overhaul"
+```
+
+---
+
+## Task 2: Create ResultRowDetail Component (Expanded State)
+
+**Files:**
+
+- Create: `components/ResultRowDetail.tsx`
+
+The expanded detail panel — fee breakdown, Medicare comparison, avg insured, and hospital profile link. Two-column layout (breakdown left, meta right).
+
+- [ ] **Step 1: Create ResultRowDetail**
+
+```tsx
+// components/ResultRowDetail.tsx
+"use client";
+
+import { formatPrice, getDisplayPrice } from "@/lib/format";
+import type { ChargeResult } from "@/types";
+
+interface ResultRowDetailProps {
+  result: ChargeResult;
+}
+
+const notNull = (v: string | undefined): v is string =>
+  !!v && v.toLowerCase() !== "null";
+
+export function ResultRowDetail({ result }: ResultRowDetailProps) {
+  const displayPrice = getDisplayPrice(result);
+  const estTotal =
+    result.estimatedTotalMedian ?? result.episodeEstimate?.estimatedAllInMedian;
+
+  const address = [
+    result.provider.address,
+    result.provider.city,
+    [result.provider.state, result.provider.zip].filter(notNull).join(" "),
+  ]
+    .filter(notNull)
+    .join(", ");
+
+  const billingClassNote =
+    result.billingClass?.toLowerCase() === "facility"
+      ? "Facility fee only — professional fees may apply separately"
+      : result.billingClass?.toLowerCase() === "professional"
+        ? "Professional fee only — facility charges may apply separately"
+        : null;
+
+  return (
+    <div
+      style={{
+        background: "var(--cc-primary-light)",
+        borderBottom: "1px solid var(--cc-border)",
+      }}
+    >
+      <div style={{ padding: "12px 16px" }} className="flex gap-4">
+        {/* Left — fee breakdown */}
+        <div className="flex-1 min-w-0">
+          {address && (
+            <p
+              className="text-[12px] mb-2.5"
+              style={{ color: "var(--cc-text-secondary)" }}
+            >
+              {address}
+            </p>
+          )}
+
+          <div
+            className="rounded-md p-3"
+            style={{
+              background: "var(--cc-surface)",
+              border: "1px solid var(--cc-border)",
+            }}
+          >
+            <p
+              className="text-[10px] font-bold uppercase tracking-wider mb-2"
+              style={{ color: "var(--cc-text-tertiary)" }}
+            >
+              Fee Breakdown
+            </p>
+            <div className="flex justify-between py-1 text-[13px]">
+              <span style={{ color: "var(--cc-text-secondary)" }}>
+                {result.billingClass?.toLowerCase() === "professional"
+                  ? "Professional Fee"
+                  : "Facility Fee"}
+              </span>
+              <span
+                className="font-semibold"
+                style={{ color: "var(--cc-text)" }}
+              >
+                {formatPrice(displayPrice.amount)}
+              </span>
+            </div>
+            {billingClassNote && (
+              <div className="flex justify-between py-1 text-[13px]">
+                <span style={{ color: "var(--cc-text-secondary)" }}>
+                  {result.billingClass?.toLowerCase() === "facility"
+                    ? "Professional Fee"
+                    : "Facility Fee"}
+                </span>
+                <span
+                  className="text-[12px] italic"
+                  style={{ color: "var(--cc-accent)" }}
+                >
+                  Billed separately
+                </span>
+              </div>
+            )}
+            {estTotal && estTotal !== displayPrice.amount && (
+              <div
+                className="flex justify-between py-1.5 mt-1 text-[13px]"
+                style={{ borderTop: "1px solid var(--cc-border)" }}
+              >
+                <span
+                  className="font-semibold"
+                  style={{ color: "var(--cc-text)" }}
+                >
+                  Estimated Total
+                </span>
+                <span
+                  className="font-bold text-[15px]"
+                  style={{ color: "var(--cc-primary)" }}
+                >
+                  {formatPrice(estTotal)}
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Right — meta + CTA */}
+        <div
+          className="flex flex-col gap-2 justify-between"
+          style={{ minWidth: 170 }}
+        >
+          {result.medicareFacilityRate != null && (
+            <div className="text-[12px]">
+              <span style={{ color: "var(--cc-text-tertiary)" }}>
+                Medicare:{" "}
+              </span>
+              <span
+                className="font-semibold"
+                style={{ color: "var(--cc-success)" }}
+              >
+                {formatPrice(result.medicareFacilityRate)}
+              </span>
+              {result.medicareMultiplier != null &&
+                result.medicareMultiplier > 1 && (
+                  <span
+                    className="text-[10px] font-semibold px-1.5 py-0.5 rounded ml-1"
+                    style={{
+                      background: "var(--cc-accent-light)",
+                      color: "var(--cc-accent)",
+                    }}
+                  >
+                    {result.medicareMultiplier}×
+                  </span>
+                )}
+            </div>
+          )}
+          {result.avgNegotiatedRate != null && (
+            <div className="text-[12px]">
+              <span style={{ color: "var(--cc-text-tertiary)" }}>
+                Avg Insured:{" "}
+              </span>
+              <span
+                className="font-semibold"
+                style={{ color: "var(--cc-info)" }}
+              >
+                {formatPrice(result.avgNegotiatedRate)}
+              </span>
+              {result.payerCount != null && result.payerCount > 0 && (
+                <span style={{ color: "var(--cc-text-tertiary)" }}>
+                  {" "}
+                  ({result.payerCount} payers)
+                </span>
+              )}
+            </div>
+          )}
+          <button
+            className="text-[12px] font-semibold px-3 py-1.5 rounded-md transition-colors mt-auto"
+            style={{
+              background: "var(--cc-surface)",
+              border: "1px solid var(--cc-primary)",
+              color: "var(--cc-primary)",
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            View Hospital Profile →
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/ResultRowDetail.tsx
+git commit -m "feat: add ResultRowDetail fee breakdown component"
+```
+
+---
+
+## Task 3: Update ResultsList to Use Table Layout
+
+**Files:**
+
+- Modify: `components/ResultsList.tsx`
+
+Replace card-based rendering with column headers + ResultRow + ResultRowDetail.
+
+- [ ] **Step 1: Update imports and add column headers**
+
+Replace the `ResultCard` import with `ResultRow` and `ResultRowDetail`. Add a column headers row above the results. Keep all existing state logic (expandedIds, marker click effects) — just change what renders.
+
+Key changes:
+
+- Import `ResultRow` and `ResultRowDetail` instead of `ResultCard`
+- Add a sticky column header row matching the grid: Provider | Est. Total | Base Price | Distance | Quality
+- Replace `<ResultCard>` rendering with `<ResultRow>` + conditional `<ResultRowDetail>`
+- Thread `codeDescriptionMap` prop through to `ResultRowDetail` (currently passed to ResultCard for billing code description display — intentionally dropped from ResultRow collapsed state but keep available in expanded detail if needed later)
+- Remove `animate-fade-up` staggered animation (table rows shouldn't slide in individually)
+- Update loading skeleton to match table-row proportions
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 3: Run lint**
+
+Run: `npm run lint`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/ResultsList.tsx
+git commit -m "feat: switch ResultsList from cards to table rows with column headers"
+```
+
+---
+
+## Task 4: Add Inline Search Variant to SearchBar
+
+**Files:**
+
+- Modify: `components/SearchBar.tsx`
+
+Add an `inline` variant that renders as a single tight row suitable for the navbar — no wrapping, no shadow, minimal padding. Reuses existing state/validation logic.
+
+- [ ] **Step 1: Add `inline` to the props and render a compact row variant**
+
+When `inline` is true:
+
+- No border-radius wrapper, no shadow
+- Query input + location input + button in a tight flex row
+- Smaller padding (py-1.5 px-2), smaller font (text-[13px])
+- Location input narrower (w-36)
+- Button: small pill (px-3 py-1.5 text-[13px])
+- No placeholders rotation — just static placeholder text
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/SearchBar.tsx
+git commit -m "feat: add inline search bar variant for navbar integration"
+```
+
+---
+
+## Task 5: Integrate Search + Interpretation into Navbar
+
+**Files:**
+
+- Modify: `components/Navbar.tsx`
+- Modify: `app/results/page.tsx`
+
+The Navbar needs to accept optional search props and render the inline SearchBar + interpretation text when on the results page.
+
+- [ ] **Step 1: Add optional search props to Navbar**
+
+```tsx
+interface NavbarProps {
+  searchBar?: React.ReactNode;
+  interpretation?: React.ReactNode;
+}
+```
+
+When `searchBar` is provided, render it between the logo and the nav links. When `interpretation` is provided, render it as inline text (truncated, small font) after the search bar.
+
+- [ ] **Step 2: Create NavbarContext for search slot injection**
+
+Create `components/NavbarContext.tsx`:
+
+```tsx
+"use client";
+import { createContext, useContext, useState, type ReactNode } from "react";
+
+interface NavbarContextValue {
+  searchSlot: ReactNode | null;
+  setSearchSlot: (node: ReactNode | null) => void;
+}
+
+const NavbarContext = createContext<NavbarContextValue>({
+  searchSlot: null,
+  setSearchSlot: () => {},
+});
+
+export function NavbarProvider({ children }: { children: ReactNode }) {
+  const [searchSlot, setSearchSlot] = useState<ReactNode | null>(null);
+  return (
+    <NavbarContext.Provider value={{ searchSlot, setSearchSlot }}>
+      {children}
+    </NavbarContext.Provider>
+  );
+}
+
+export const useNavbarSlot = () => useContext(NavbarContext);
+```
+
+Add `NavbarProvider` to the `Providers` wrapper in `components/Providers.tsx`. In `Navbar.tsx`, call `useNavbarSlot()` and render `searchSlot` between logo and nav links when present. In the results page, call `setSearchSlot()` via useEffect to inject the inline search bar + interpretation.
+
+- [ ] **Step 3: Update results page to inject search into navbar**
+
+In `app/results/page.tsx`:
+
+- Remove the standalone `<SearchBar compact>` from the page body
+- Remove the `<InterpretationBanner>` component
+- Add a `useEffect` that calls `setSearchSlot(<InlineSearch ... />)` on mount and `setSearchSlot(null)` on unmount
+- The inline search component renders the SearchBar (inline variant) + interpretation text
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/NavbarContext.tsx components/Navbar.tsx components/Providers.tsx app/results/page.tsx
+git commit -m "feat: integrate search bar and interpretation into navbar on results page"
+```
+
+---
+
+## Task 6: Update Results Page Layout (50/50 Split)
+
+**Depends on:** Task 5 (both modify `app/results/page.tsx` — execute sequentially)
+
+**Files:**
+
+- Modify: `app/results/page.tsx`
+
+Change the split from 55/45 to 50/50. Remove dead space — search bar is in nav, interpretation is in nav, so the page body starts directly with filters → results+map.
+
+- [ ] **Step 1: Update the split layout**
+
+Changes:
+
+- Remove `<SearchBar>` from page body (moved to nav in Task 5)
+- Remove `<InterpretationBanner>` (moved to nav in Task 5)
+- Change `lg:w-[55%]` → `lg:w-1/2` and `lg:w-[45%]` → `lg:w-1/2`
+- Reduce top padding — filters should start near the top
+- Update `maxHeight` calc to account for thinner nav (no search bar row below)
+- Keep the `CostContextBanner` — but consider making it dismissible (it currently takes space)
+
+- [ ] **Step 2: Compact the FilterBar**
+
+In `components/FilterBar.tsx`:
+
+- Reduce select padding (height 28px instead of 32px)
+- Tighter gap (gap-2 instead of gap-3)
+- Smaller font (text-[12px])
+- Remove labels like "Within" and "Sort" — use placeholders inside selects instead
+
+- [ ] **Step 3: Verify full flow**
+
+Run: `npx tsc --noEmit && npm run lint`
+Expected: PASS
+
+- [ ] **Step 4: Visual QA**
+
+Run: `npm run dev` and verify:
+
+- Search bar renders in nav on results page
+- Interpretation shows inline after search
+- Filters are one compact row
+- Results table has column headers
+- Clicking a row expands fee breakdown
+- Map takes 50% of screen width
+- Map markers still work (click, hover, selection highlight)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/results/page.tsx components/FilterBar.tsx
+git commit -m "feat: 50/50 split layout, compact filters, remove dead space"
+```
+
+---
+
+## Task 7: Mobile Responsive Adjustments
+
+**Files:**
+
+- Modify: `components/ResultRow.tsx`
+- Modify: `components/ResultRowDetail.tsx`
+- Modify: `components/ResultsList.tsx`
+- Modify: `app/results/page.tsx`
+
+Mobile needs different treatment — table columns don't work at 375px.
+
+- [ ] **Step 1: Mobile ResultRow**
+
+On mobile (< lg breakpoint):
+
+- Hide Est. Total and Quality columns (show only Provider, Base Price, Distance, Chevron)
+- Grid changes to `1fr 80px 60px 24px`
+- Provider name can use more space
+- Interpretation in nav collapses to just the code pill (CPT 71046) on mobile, full text on desktop
+
+- [ ] **Step 2: Mobile layout**
+
+On mobile:
+
+- Results and map are toggled (existing pill toggle behavior — keep it)
+- Filter row scrolls horizontally if needed
+- Expanded detail stacks vertically (flex-col instead of flex-row)
+
+- [ ] **Step 3: Test at 375px**
+
+Use browser devtools to verify layout at 375px width.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/ResultRow.tsx components/ResultRowDetail.tsx components/ResultsList.tsx app/results/page.tsx
+git commit -m "feat: mobile responsive adjustments for table layout"
+```
+
+---
+
+## Execution Notes
+
+**What's NOT in scope:**
+
+- Quality stars column data (#141 — separate issue, shows "—" placeholder for now)
+- Hospital Profile page (separate feature — button is a placeholder)
+- Provider Comparison view (separate feature)
+- Deleting ResultCard.tsx (keep it — may still be used elsewhere or as fallback)
+
+**Risk assessment:**
+
+- MEDIUM: Navbar search integration — the portal/slot pattern needs careful implementation since Navbar is in layout.tsx but search state lives in the results page
+- LOW: ResultRow/ResultRowDetail — straightforward new components
+- LOW: Layout change (50/50) — CSS only
+- MEDIUM: Mobile responsive — need to test thoroughly since we're changing from cards to table rows
+
+**Estimated effort:** ~45 min CC time

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1,5 +1,9 @@
 import type { ChargeResult } from "@/types";
 
+/** Type guard: checks that a string value is present and not the literal "null" */
+export const notNull = (v: string | undefined): v is string =>
+  !!v && v.toLowerCase() !== "null";
+
 export function formatPrice(price: number | undefined): string {
   if (price == null) return "N/A";
   return `$${price.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;


### PR DESCRIPTION
## Summary
Complete overhaul of the results page display:
- **Table layout** replaces accordion cards — proper `<table>` with `<thead>` (sticky) and `<tbody>` for pixel-perfect column alignment
- **Search bar in navbar** via NavbarContext — frees vertical space for results
- **50/50 split** (was 55/45) — map gets more room
- **Price color-coding** — green (low 33%), amber (mid), red (high) based on result range
- **Fee breakdown detail** — expanded row shows facility fee, professional fee (billed separately), estimated total, Medicare comparison, avg insured
- **Interpretation as hover tooltip** — "Interpreted: CPT 73721" pill with ? icon, full explanation on hover
- **Filters flush below navbar** — no dead space between nav and results
- **Results count in filter bar** — not a standalone line
- **Removed CostContextBanner** — base vs estimated price makes additional fees self-evident
- **Mobile: horizontal scroll** on filter bar instead of wrapping

## Files Changed (8 source files)
- `components/ResultRow.tsx` — New table row component (`<tr>` with `<td>` cells)
- `components/ResultRowDetail.tsx` — Expanded detail panel (fee breakdown, Medicare, profile CTA)
- `components/ResultsList.tsx` — Table layout with sticky headers, price range computation
- `components/NavbarContext.tsx` — React context for navbar slot injection
- `components/Navbar.tsx` — Renders search slot when present
- `components/Providers.tsx` — Wraps children in NavbarProvider
- `components/SearchBar.tsx` — Widened location input (w-52)
- `app/results/page.tsx` — Search in navbar, compact filter bar, 50/50 split
- `lib/format.ts` — Extracted shared `notNull` helper

## Code Quality
- `/simplify` review: extracted `notNull` to shared utility, removed unused props (`rank`, `codeDescriptionMap`), stabilized `onSelect` callback
- `/qa` run: tested desktop + mobile, 1 fix applied (filter bar overflow), no console errors
- `/plan-eng-review`: 1 issue found and fixed (JS hover → CSS hover)
- `/plan-design-review`: score 6/10 → 8/10, added interaction states + a11y + mobile specs

## Known Issues
- #143: Mobile search bar in navbar needs responsive treatment (cramped at 375px)
- Quality column shows "—" placeholder until #141 (CMS star ratings import)
- "View Hospital Profile" button is a placeholder (no hospital profile page yet)

## Test plan
- [x] All 75 Vitest tests pass
- [x] QA'd desktop results page — table layout, expand/collapse, map interaction
- [x] QA'd mobile (375px) — columns hide, filter bar scrolls
- [x] No console errors
- [ ] Visual check: column alignment with real data
- [ ] Test guided search → results flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)